### PR TITLE
Label histogram and ROI axes in viewer

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -131,6 +131,16 @@ class MainWindow(QMainWindow):
         layout.addLayout(right, 1)
 
         self.view = pg.ImageView()
+        # Label histogram and ROI plot axes for clarity
+        hist = self.view.getHistogramWidget()
+        if hist is not None and hasattr(hist, 'axis'):
+            hist.axis.setLabel("Pixel intensity", color="#FFFFFF")
+        roi_plot = self.view.getRoiPlot()
+        if roi_plot is not None:
+            roi_plot.getAxis('bottom').setLabel("Frame", color="#FFFFFF")
+            roi_plot.getAxis('left').setLabel("Mean intensity", color="#FFFFFF")
+            roi_plot.showAxis('bottom', True)
+            roi_plot.showAxis('left', True)
         right.addWidget(self.view)
 
         overlay_box = QHBoxLayout()


### PR DESCRIPTION
## Summary
- Add axis labels for the ImageView histogram and ROI plot.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffec3cf8883248cb35aa64d053f53