### PR TITLE
Select red channel for grayscale loading

### DIFF
--- a/app/core/io_utils.py
+++ b/app/core/io_utils.py
@@ -30,7 +30,7 @@ def imread_gray(path: Path) -> np.ndarray:
     if img is None:
         raise ValueError(f"Failed to read {path}")
     if img.ndim == 3:
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        img = img[..., 2]
     if img.dtype != np.uint8:
         img = cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
     return img

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -356,8 +356,8 @@ class MainWindow(QMainWindow):
                          morph_close_radius=seg.morph_close_radius,
                          remove_objects_smaller_px=seg.remove_objects_smaller_px,
                          remove_holes_smaller_px=seg.remove_holes_smaller_px)
-            self._seg_gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
-            self._seg_overlay = overlay_outline(gray, bw)
+            self._seg_gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
+            self._seg_overlay = cv2.cvtColor(overlay_outline(gray, bw), cv2.COLOR_BGR2RGB)
             self._current_preview = "segmentation"
             # Blend and push the new image to the viewer
             self._refresh_overlay_alpha()


### PR DESCRIPTION
## Summary
- Use red channel when reading grayscale images to avoid OpenCV conversions
- Display segmentation preview as RGB while processing single-channel data

## Testing
- `python -m py_compile app/core/io_utils.py app/ui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c011d03af48324a4475e0260d565e3