### PR TITLE
Persist settings on close

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -59,6 +59,7 @@ def save_settings(reg: RegParams, seg: SegParams, app: AppParams) -> None:
     s.setValue("reg", json.dumps(asdict(reg)))
     s.setValue("seg", json.dumps(asdict(seg)))
     s.setValue("app", json.dumps(asdict(app)))
+    s.sync()
 
 def load_settings() -> tuple[RegParams, SegParams, AppParams]:
     s = QSettings("YeastLab", "FlowcellPyQt")

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -216,7 +216,6 @@ class MainWindow(QMainWindow):
                         custom_ref_index=self.ref_idx.value(),
                         minutes_between_frames=self.dt_min.value(),
                         use_file_timestamps=self.use_ts.isChecked())
-        save_settings(reg, seg, app)
         return reg, seg, app
 
     def _save_preset(self):
@@ -404,3 +403,9 @@ class MainWindow(QMainWindow):
         QMessageBox.critical(self, "Error", err)
         self.status_label.setText("Failed.")
         self.thread.quit(); self.thread.wait()
+
+    def closeEvent(self, event):
+        """Persist current settings when the window is closed."""
+        reg, seg, app = self._collect_params()
+        save_settings(reg, seg, app)
+        super().closeEvent(event)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,29 @@
+import os
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QSettings
+from app.ui.main_window import MainWindow
+
+
+def test_settings_persist(tmp_path):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    s = QSettings("YeastLab", "FlowcellPyQt")
+    s.clear()
+    s.sync()
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.max_iters.setValue(321)
+    win.seg_method.setCurrentText("manual")
+    win.ref_combo.setCurrentText("first")
+    win.close()
+    app.processEvents()
+
+    win2 = MainWindow()
+    assert win2.max_iters.value() == 321
+    assert win2.seg_method.currentText() == "manual"
+    assert win2.ref_combo.currentText() == "first"
+    win2.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Ensure settings are flushed to disk by calling `QSettings.sync`
- Save current UI parameters when the main window closes
- Add test validating that saved settings repopulate the UI on restart

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c013ac95e48324a805ca0bf6085fe0