### PR TITLE
Persist last chosen folder

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -43,6 +43,7 @@ class AppParams:
     use_difference_for_seg: bool = False
     use_file_timestamps: bool = True
     presets_path: Optional[str] = None
+    last_folder: str | None = None
 
 def save_preset(path: str, reg: RegParams, seg: SegParams, app: AppParams) -> None:
     data = {"reg": asdict(reg), "seg": asdict(seg), "app": asdict(app)}

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -44,6 +44,8 @@ class MainWindow(QMainWindow):
         # Folder
         folder_box = QHBoxLayout()
         self.folder_edit = QLineEdit()
+        if self.app.last_folder:
+            self.folder_edit.setText(self.app.last_folder)
         browse_btn = QPushButton("Browse…")
         browse_btn.clicked.connect(self._choose_folder)
         folder_box.addWidget(self.folder_edit)
@@ -164,6 +166,15 @@ class MainWindow(QMainWindow):
         self.status_label = QLabel("Ready.")
         right.addWidget(self.status_label)
 
+        if self.app.last_folder:
+            p = Path(self.app.last_folder)
+            self.paths = discover_images(p)
+            if self.paths:
+                idx = self._show_reference_frame()
+                if idx is not None:
+                    self.status_label.setText(
+                        f"Found {len(self.paths)} images. Preview: {self.paths[idx].name}")
+
     def _show_reference_frame(self):
         """Display the frame chosen by the current reference settings."""
         if not self.paths:
@@ -186,6 +197,8 @@ class MainWindow(QMainWindow):
         d = QFileDialog.getExistingDirectory(self, "Select image folder", "")
         if d:
             self.folder_edit.setText(d)
+            self.app.last_folder = d
+            save_settings(self.reg, self.seg, self.app)
             self.paths = discover_images(Path(d))
             if not self.paths:
                 QMessageBox.warning(self, "No images", "No images found.")


### PR DESCRIPTION
## Summary
- Add `last_folder` to `AppParams` and persist it in settings
- Pre-fill folder field and image paths on startup from saved `last_folder`
- Save chosen folder immediately when browsing

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: repository InRelease not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c01a03e5888324aa92af0a7699dec1