### PR TITLE
Persist overlay settings for UI

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -37,6 +37,9 @@ class AppParams:
     minutes_between_frames: float = 1.0  # default; can be overridden by timestamps
     reference_choice: str = "last"  # last | first | middle | custom
     custom_ref_index: int = 0
+    show_ref_overlay: bool = True
+    show_mov_overlay: bool = True
+    overlay_opacity: int = 50
     save_jpg_quality: int = 95
     save_png: bool = False
     save_intermediates: bool = True

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -148,9 +148,9 @@ class MainWindow(QMainWindow):
         right.addWidget(self.view)
 
         overlay_box = QHBoxLayout()
-        self.overlay_ref_cb = QCheckBox("Show reference overlay"); self.overlay_ref_cb.setChecked(True)
-        self.overlay_mov_cb = QCheckBox("Show moving overlay"); self.overlay_mov_cb.setChecked(True)
-        self.alpha_slider = QSlider(Qt.Orientation.Horizontal); self.alpha_slider.setRange(0,100); self.alpha_slider.setValue(50)
+        self.overlay_ref_cb = QCheckBox("Show reference overlay"); self.overlay_ref_cb.setChecked(self.app.show_ref_overlay)
+        self.overlay_mov_cb = QCheckBox("Show moving overlay"); self.overlay_mov_cb.setChecked(self.app.show_mov_overlay)
+        self.alpha_slider = QSlider(Qt.Orientation.Horizontal); self.alpha_slider.setRange(0,100); self.alpha_slider.setValue(self.app.overlay_opacity)
         overlay_box.addWidget(self.overlay_ref_cb)
         overlay_box.addWidget(self.overlay_mov_cb)
         overlay_box.addWidget(QLabel("Opacity"))
@@ -228,7 +228,10 @@ class MainWindow(QMainWindow):
         app = AppParams(reference_choice=self.ref_combo.currentText(),
                         custom_ref_index=self.ref_idx.value(),
                         minutes_between_frames=self.dt_min.value(),
-                        use_file_timestamps=self.use_ts.isChecked())
+                        use_file_timestamps=self.use_ts.isChecked(),
+                        show_ref_overlay=self.overlay_ref_cb.isChecked(),
+                        show_mov_overlay=self.overlay_mov_cb.isChecked(),
+                        overlay_opacity=self.alpha_slider.value())
         return reg, seg, app
 
     def _save_preset(self):
@@ -263,6 +266,9 @@ class MainWindow(QMainWindow):
         self.ref_idx.setValue(app.custom_ref_index)
         self.dt_min.setValue(app.minutes_between_frames)
         self.use_ts.setChecked(app.use_file_timestamps)
+        self.overlay_ref_cb.setChecked(app.show_ref_overlay)
+        self.overlay_mov_cb.setChecked(app.show_mov_overlay)
+        self.alpha_slider.setValue(app.overlay_opacity)
         self.status_label.setText(f"Preset loaded: {path}")
 
     def _refresh_overlay_alpha(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,9 @@ def test_settings_persist(tmp_path):
     win.max_iters.setValue(321)
     win.seg_method.setCurrentText("manual")
     win.ref_combo.setCurrentText("first")
+    win.overlay_ref_cb.setChecked(False)
+    win.overlay_mov_cb.setChecked(False)
+    win.alpha_slider.setValue(75)
     win.close()
     app.processEvents()
 
@@ -25,5 +28,8 @@ def test_settings_persist(tmp_path):
     assert win2.max_iters.value() == 321
     assert win2.seg_method.currentText() == "manual"
     assert win2.ref_combo.currentText() == "first"
+    assert not win2.overlay_ref_cb.isChecked()
+    assert not win2.overlay_mov_cb.isChecked()
+    assert win2.alpha_slider.value() == 75
     win2.close()
     app.quit()


### PR DESCRIPTION
## Summary
- track overlay visibility and opacity in `AppParams`
- initialize overlay checkboxes and opacity slider from saved settings
- save and load overlay options and test their persistence

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c01b833304832482d0423fa6d9be05