### PR TITLE
Remember last preset directory

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -255,6 +255,7 @@ class MainWindow(QMainWindow):
                         show_ref_overlay=self.overlay_ref_cb.isChecked(),
                         show_mov_overlay=self.overlay_mov_cb.isChecked(),
                         overlay_opacity=self.alpha_slider.value())
+        app.presets_path = self.app.presets_path
         return reg, seg, app
 
     def _persist_settings(self, *args):
@@ -267,16 +268,20 @@ class MainWindow(QMainWindow):
         return reg, seg, app
 
     def _save_preset(self):
-        reg, seg, app = self._persist_settings()
-        path, _ = QFileDialog.getSaveFileName(self, "Save Preset", "preset.json", "JSON (*.json)")
+        reg, seg, _ = self._persist_settings()
+        initial = str(Path(self.app.presets_path) / "preset.json") if self.app.presets_path else "preset.json"
+        path, _ = QFileDialog.getSaveFileName(self, "Save Preset", initial, "JSON (*.json)")
         if path:
-            save_preset(path, reg, seg, app)
+            self.app.presets_path = str(Path(path).parent)
+            save_preset(path, reg, seg, self.app)
+            save_settings(self.reg, self.seg, self.app)
             self.status_label.setText(f"Preset saved: {path}")
 
     def _load_preset(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Load Preset", "", "JSON (*.json)")
+        path, _ = QFileDialog.getOpenFileName(self, "Load Preset", self.app.presets_path or "", "JSON (*.json)")
         if not path: return
         reg, seg, app = load_preset(path)
+        app.presets_path = str(Path(path).parent)
         self.reg = reg; self.seg = seg; self.app = app
         # Update UI
         self.reg_method.setCurrentText(reg.method)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,8 @@
 import os
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QFileDialog
 from PyQt6.QtCore import QSettings
 from app.ui.main_window import MainWindow
+from app.models.config import save_preset, RegParams, SegParams, AppParams
 
 
 def test_settings_persist(tmp_path):
@@ -32,4 +33,54 @@ def test_settings_persist(tmp_path):
     assert not win2.overlay_mov_cb.isChecked()
     assert win2.alpha_slider.value() == 75
     win2.close()
+    app.quit()
+
+
+def test_presets_path_persist(tmp_path, monkeypatch):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    s = QSettings("YeastLab", "FlowcellPyQt")
+    s.clear(); s.sync()
+
+    preset_dir1 = tmp_path / "presets1"
+    preset_dir1.mkdir()
+    preset_file1 = preset_dir1 / "preset1.json"
+
+    def fake_save(parent, caption, dir, filter):
+        return str(preset_file1), "JSON (*.json)"
+
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", fake_save)
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win._save_preset()
+    assert win.app.presets_path == str(preset_dir1)
+    win.close()
+    app.processEvents()
+
+    # Persisted in settings
+    win2 = MainWindow()
+    assert win2.app.presets_path == str(preset_dir1)
+
+    # Prepare second preset to load
+    preset_dir2 = tmp_path / "presets2"
+    preset_dir2.mkdir()
+    preset_file2 = preset_dir2 / "preset2.json"
+    save_preset(str(preset_file2), RegParams(), SegParams(), AppParams())
+
+    def fake_open(parent, caption, dir, filter):
+        assert dir == str(preset_dir1)
+        return str(preset_file2), "JSON (*.json)"
+
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", fake_open)
+    win2._load_preset()
+    assert win2.app.presets_path == str(preset_dir2)
+    win2.close()
+
+    # Ensure path persisted
+    win3 = MainWindow()
+    assert win3.app.presets_path == str(preset_dir2)
+    win3.close()
     app.quit()


### PR DESCRIPTION
## Summary
- Track a presets directory and use it as the starting location when saving or loading presets
- Persist the chosen presets directory in settings and restore it across sessions
- Add tests to ensure preset path persistence

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y libgl1` *(fails: Unable to locate package libgl1)*

------
https://chatgpt.com/codex/tasks/task_e_68c01dc4cb388324b725a7e081943d34