### PR TITLE
Persist last folder selection in settings

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -243,8 +243,8 @@ class MainWindow(QMainWindow):
         d = QFileDialog.getExistingDirectory(self, "Select image folder", "")
         if d:
             self.folder_edit.setText(d)
-            # Persist the chosen folder along with current settings
-            self._persist_settings()
+            self.app.last_folder = d
+            save_settings(self.reg, self.seg, self.app)
             self.paths = discover_images(Path(d))
             if not self.paths:
                 QMessageBox.warning(self, "No images", "No images found.")


### PR DESCRIPTION
## Summary
- Track the last image folder via `AppParams.last_folder` and prefill the folder field on startup
- Load images from the remembered folder on launch
- Immediately save the chosen folder when browsing to a new directory

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c02b6e264c8324be4d0f773b304642