### PR TITLE
Persist settings after folder selection

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -243,8 +243,8 @@ class MainWindow(QMainWindow):
         d = QFileDialog.getExistingDirectory(self, "Select image folder", "")
         if d:
             self.folder_edit.setText(d)
-            self.app.last_folder = d
-            save_settings(self.reg, self.seg, self.app)
+            # Persist the newly selected folder alongside other parameters
+            self._persist_settings()
             self.paths = discover_images(Path(d))
             if not self.paths:
                 QMessageBox.warning(self, "No images", "No images found.")


### PR DESCRIPTION
## Summary
- Use central `_persist_settings` helper when choosing a new image folder so the selected path and other parameters are saved.

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68c02eec4d708324bfa072a5d706501a