### PR TITLE
Use cvtColor for proper grayscale conversion

### DIFF
--- a/app/core/io_utils.py
+++ b/app/core/io_utils.py
@@ -30,7 +30,7 @@ def imread_gray(path: Path) -> np.ndarray:
     if img is None:
         raise ValueError(f"Failed to read {path}")
     if img.ndim == 3:
-        img = img[..., 2]
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     if img.dtype != np.uint8:
         img = cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
     return img


### PR DESCRIPTION
## Summary
- use cv2.cvtColor to convert color images to grayscale in `imread_gray`
- preserve normalization of non-uint8 images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03b830a2c83248c0260ad4e43db45