### PR TITLE
Fix Otsu segmentation logic and add tests

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -25,8 +25,8 @@ def segment(gray: np.ndarray, method: str="otsu", invert: bool=True,
     else:
         feat = outline_focused(gray, invert=invert)
         if method == "otsu":
-            _, th = cv2.threshold(feat, 0, 255, cv2.THRESH_BINARY+cv2.THRESH_OTSU)
-            bw = (feat >= _).astype(np.uint8)
+            _, th = cv2.threshold(feat, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+            bw = (th > 0).astype(np.uint8)
         elif method == "adaptive":
             blk = max(3, adaptive_block|1)
             th = cv2.adaptiveThreshold(feat, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, blk, adaptive_C)

--- a/tests/test_segmentation_otsu.py
+++ b/tests/test_segmentation_otsu.py
@@ -1,0 +1,34 @@
+import numpy as np
+import sys
+from pathlib import Path
+import cv2
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment, outline_focused
+
+
+def test_otsu_segmentation_matches_cv2_threshold():
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+
+    seg = segment(
+        img,
+        method="otsu",
+        invert=False,
+        morph_open_radius=0,
+        morph_close_radius=0,
+        remove_objects_smaller_px=0,
+        remove_holes_smaller_px=0,
+    )
+
+    feat = outline_focused(img, invert=False)
+    _, th = cv2.threshold(feat, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    expected = (th > 0).astype(np.uint8)
+
+    assert np.array_equal(seg, expected)
+


### PR DESCRIPTION
## Summary
- correct Otsu segmentation to use OpenCV's thresholded mask
- add test ensuring Otsu segmentation output matches OpenCV

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03d43c8cc83249bb4b185748532a9