### PR TITLE
Allow configurable reference frame in analysis

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -19,8 +19,19 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     imgs_gray = [imread_gray(p) for p in paths]
     H, W = imgs_gray[0].shape[:2]
 
-    # Always use the last frame as the starting reference
-    ref_idx = len(paths) - 1
+    # Determine starting reference frame based on user selection
+    ref_choice = app_cfg.get("reference_choice", "last")
+    if ref_choice == "first":
+        ref_idx = 0
+    elif ref_choice == "middle":
+        ref_idx = len(paths) // 2
+    elif ref_choice == "custom":
+        # Clamp custom index to valid range
+        ref_idx = int(app_cfg.get("custom_ref_index", 0))
+        ref_idx = max(0, min(len(paths) - 1, ref_idx))
+    else:
+        # Default to using the last frame
+        ref_idx = len(paths) - 1
 
     # Background normalization using early frames
     bg = estimate_temporal_background(imgs_gray, n_early=5)

--- a/tests/test_reference_choice.py
+++ b/tests/test_reference_choice.py
@@ -1,0 +1,71 @@
+import numpy as np
+import cv2
+from pathlib import Path
+import sys
+
+# Ensure the application package is importable when tests are run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.core.processing import analyze_sequence
+
+
+def create_dummy_images(tmp_path, n=3):
+    paths = []
+    for i in range(n):
+        img = np.zeros((10, 10), dtype=np.uint8)
+        cv2.imwrite(str(tmp_path / f"img_{i}.png"), img)
+        paths.append(tmp_path / f"img_{i}.png")
+    return paths
+
+
+def run_analyze(paths, reference_choice, custom_index=0):
+    reg_cfg = {
+        "model": "affine",
+        "max_iters": 1,
+        "gauss_blur_sigma": 0,
+        "clahe_clip": 0,
+        "clahe_grid": 8,
+        "use_masked_ecc": False,
+    }
+    seg_cfg = {
+        "method": "manual",
+        "manual_thresh": 0,
+        "invert": True,
+        "morph_open_radius": 0,
+        "morph_close_radius": 0,
+        "remove_objects_smaller_px": 0,
+        "remove_holes_smaller_px": 0,
+    }
+    app_cfg = {
+        "reference_choice": reference_choice,
+        "custom_ref_index": custom_index,
+        "save_intermediates": False,
+    }
+    out_dir = paths[0].parent / "out"
+    df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
+    # Extract the index of the reference frame
+    return int(df.loc[df["is_reference"], "frame_index"].iloc[0])
+
+
+def test_reference_last(tmp_path):
+    paths = create_dummy_images(tmp_path)
+    ref = run_analyze(paths, "last")
+    assert ref == len(paths) - 1
+
+
+def test_reference_first(tmp_path):
+    paths = create_dummy_images(tmp_path)
+    ref = run_analyze(paths, "first")
+    assert ref == 0
+
+
+def test_reference_middle(tmp_path):
+    paths = create_dummy_images(tmp_path)
+    ref = run_analyze(paths, "middle")
+    assert ref == len(paths) // 2
+
+
+def test_reference_custom(tmp_path):
+    paths = create_dummy_images(tmp_path)
+    ref = run_analyze(paths, "custom", custom_index=1)
+    assert ref == 1


### PR DESCRIPTION
## Summary
- Choose the analysis reference frame based on `app_cfg` options (`last`, `first`, `middle`, or `custom`).
- Add tests verifying reference frame selection for all options.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c03e77819c83248ebcd52815fab240