### PR TITLE
Add registration preprocessing controls with context help

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,6 +17,9 @@ def test_settings_persist(tmp_path):
     app = QApplication.instance() or QApplication([])
     win = MainWindow()
     win.max_iters.setValue(321)
+    win.gauss_sigma.setValue(2.5)
+    win.clahe_clip.setValue(1.5)
+    win.clahe_grid.setValue(16)
     win.seg_method.setCurrentText("manual")
     win.ref_combo.setCurrentText("first")
     win.overlay_ref_cb.setChecked(False)
@@ -27,6 +30,9 @@ def test_settings_persist(tmp_path):
 
     win2 = MainWindow()
     assert win2.max_iters.value() == 321
+    assert win2.gauss_sigma.value() == 2.5
+    assert win2.clahe_clip.value() == 1.5
+    assert win2.clahe_grid.value() == 16
     assert win2.seg_method.currentText() == "manual"
     assert win2.ref_combo.currentText() == "first"
     assert not win2.overlay_ref_cb.isChecked()


### PR DESCRIPTION
## Summary
- Add Gaussian blur sigma and CLAHE clip/grid controls to registration pane
- Show right-click tooltips for all registration controls
- Persist new preprocessing settings and test their round-trip in QSettings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c048426e548324ba5a3a73fdd149d6