### PR TITLE
Add direction selector and update sequence analysis

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -35,8 +35,7 @@ class SegParams:
 class AppParams:
     px_size_um: float = 1.0
     minutes_between_frames: float = 1.0  # default; can be overridden by timestamps
-    reference_choice: str = "last"  # last | first | middle | custom
-    custom_ref_index: int = 0
+    direction: str = "last-to-first"  # "last-to-first" | "first-to-last"
     show_ref_overlay: bool = True
     show_mov_overlay: bool = True
     overlay_opacity: int = 50

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -18,7 +18,7 @@ def create_dummy_images(tmp_path, n=3):
     return paths
 
 
-def run_analyze(paths, reference_choice, custom_index=0):
+def run_analyze(paths, direction):
     reg_cfg = {
         "model": "affine",
         "max_iters": 1,
@@ -37,35 +37,22 @@ def run_analyze(paths, reference_choice, custom_index=0):
         "remove_holes_smaller_px": 0,
     }
     app_cfg = {
-        "reference_choice": reference_choice,
-        "custom_ref_index": custom_index,
+        "direction": direction,
         "save_intermediates": False,
     }
     out_dir = paths[0].parent / "out"
     df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
-    # Extract the index of the reference frame
     return int(df.loc[df["is_reference"], "frame_index"].iloc[0])
 
 
-def test_reference_last(tmp_path):
+def test_last_to_first(tmp_path):
     paths = create_dummy_images(tmp_path)
-    ref = run_analyze(paths, "last")
+    ref = run_analyze(paths, "last-to-first")
     assert ref == len(paths) - 1
 
 
-def test_reference_first(tmp_path):
+def test_first_to_last(tmp_path):
     paths = create_dummy_images(tmp_path)
-    ref = run_analyze(paths, "first")
+    ref = run_analyze(paths, "first-to-last")
     assert ref == 0
 
-
-def test_reference_middle(tmp_path):
-    paths = create_dummy_images(tmp_path)
-    ref = run_analyze(paths, "middle")
-    assert ref == len(paths) // 2
-
-
-def test_reference_custom(tmp_path):
-    paths = create_dummy_images(tmp_path)
-    ref = run_analyze(paths, "custom", custom_index=1)
-    assert ref == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -21,7 +21,7 @@ def test_settings_persist(tmp_path):
     win.clahe_clip.setValue(1.5)
     win.clahe_grid.setValue(16)
     win.seg_method.setCurrentText("manual")
-    win.ref_combo.setCurrentText("first")
+    win.dir_combo.setCurrentText("first-to-last")
     win.overlay_ref_cb.setChecked(False)
     win.overlay_mov_cb.setChecked(False)
     win.alpha_slider.setValue(75)
@@ -34,7 +34,7 @@ def test_settings_persist(tmp_path):
     assert win2.clahe_clip.value() == 1.5
     assert win2.clahe_grid.value() == 16
     assert win2.seg_method.currentText() == "manual"
-    assert win2.ref_combo.currentText() == "first"
+    assert win2.dir_combo.currentText() == "first-to-last"
     assert not win2.overlay_ref_cb.isChecked()
     assert not win2.overlay_mov_cb.isChecked()
     assert win2.alpha_slider.value() == 75


### PR DESCRIPTION
## Summary
- Replace reference frame picker with analysis direction selector in main window
- Iterate forward when set to first-to-last and drop middle/custom logic
- Adjust tests for new direction setting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0504478408324bdf49018075477d4