### PR TITLE
Specify ECC registration parameters in direction tests

### DIFF
--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -26,6 +26,8 @@ def run_analyze(paths, direction):
         "clahe_clip": 0,
         "clahe_grid": 8,
         "use_masked_ecc": False,
+        "method": "ECC",
+        "eps": 1e-6,
     }
     seg_cfg = {
         "method": "manual",


### PR DESCRIPTION
## Summary
- Add explicit ECC method and epsilon settings in direction tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c053ad8e0083249f259b175236e386