### PR TITLE
feat: expose ORB registration parameters

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -88,7 +88,13 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             ref_gray = prev_full[bbox_y:bbox_y + bbox_h, bbox_x:bbox_x + bbox_w]
 
             if reg_cfg.get("method", "ECC").upper() == "ORB":
-                W_step, warped, valid_mask = register_orb(ref_gray, g_norm, model=reg_cfg.get("model", "homography"))
+                W_step, warped, valid_mask = register_orb(
+                    ref_gray,
+                    g_norm,
+                    model=reg_cfg.get("model", "homography"),
+                    orb_features=int(reg_cfg.get("orb_features", 4000)),
+                    match_ratio=float(reg_cfg.get("match_ratio", 0.75)),
+                )
             else:
                 W_step, warped, valid_mask = register_ecc(
                     ref_gray,

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -19,6 +19,8 @@ class RegParams:
     initial_radius: int = 20
     growth_factor: float = 1.0
     use_masked_ecc: bool = True
+    orb_features: int = 4000
+    match_ratio: float = 0.75
 
 @dataclass
 class SegParams:

--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+import numpy as np
+import cv2
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.registration import register_orb
+
+
+def dummy_keypoints(n):
+    return [cv2.KeyPoint(float(i), float(i), 1) for i in range(n)]
+
+
+def test_orb_parameters_affect_registration(monkeypatch):
+    class DummyORB:
+        def detectAndCompute(self, img, mask):
+            kps = dummy_keypoints(10)
+            desc = np.zeros((10, 32), dtype=np.uint8)
+            return kps, desc
+
+    def fake_orb_create(n):
+        return DummyORB()
+
+    class DummyMatcher:
+        def knnMatch(self, d1, d2, k=2):
+            class Match:
+                def __init__(self, dist, q=0, t=0):
+                    self.distance = dist
+                    self.queryIdx = q
+                    self.trainIdx = t
+            m = Match(5)
+            n = Match(10)
+            return [(m, n)] * 10
+
+    def fake_bfmatcher(norm, crossCheck):
+        return DummyMatcher()
+
+    monkeypatch.setattr(cv2, "ORB_create", fake_orb_create)
+    monkeypatch.setattr(cv2, "BFMatcher", fake_bfmatcher)
+    monkeypatch.setattr(cv2, "findHomography", lambda dst, src, method, ransac: (np.eye(3, dtype=np.float32), None))
+    monkeypatch.setattr(cv2, "warpPerspective", lambda img, H, dsize, flags=0: img)
+    monkeypatch.setattr(cv2, "warpAffine", lambda img, M, dsize, flags=0: img)
+
+    ref = np.zeros((5, 5), dtype=np.uint8)
+    mov = np.zeros((5, 5), dtype=np.uint8)
+    H_good, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
+    assert H_good.shape == (3, 3)
+    H_bad, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
+    assert H_bad.shape == (2, 3)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,6 +22,9 @@ def test_settings_persist(tmp_path):
     win.clahe_grid.setValue(16)
     win.init_radius.setValue(12)
     win.growth_factor.setValue(1.8)
+    win.reg_method.setCurrentText("ORB")
+    win.orb_features.setValue(123)
+    win.match_ratio.setValue(0.55)
     win.seg_method.setCurrentText("manual")
     win.dir_combo.setCurrentText("first-to-last")
     win.overlay_ref_cb.setChecked(False)
@@ -37,6 +40,9 @@ def test_settings_persist(tmp_path):
     assert win2.clahe_grid.value() == 16
     assert win2.init_radius.value() == 12
     assert win2.growth_factor.value() == 1.8
+    assert win2.reg_method.currentText() == "ORB"
+    assert win2.orb_features.value() == 123
+    assert win2.match_ratio.value() == 0.55
     assert win2.seg_method.currentText() == "manual"
     assert win2.dir_combo.currentText() == "first-to-last"
     assert not win2.overlay_ref_cb.isChecked()


### PR DESCRIPTION
## Summary
- add `orb_features` and `match_ratio` to registration config
- surface ORB options in the registration UI and pipeline
- verify ORB parameters persist and affect registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05f8cb46c8324a7477f465db4fb75