### PR TITLE
Add configurable intensity normalization for image loading

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -16,7 +16,9 @@ def overlay_outline(gray: np.ndarray, mask: np.ndarray) -> np.ndarray:
     return color
 
 def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: dict, out_dir: Path) -> pd.DataFrame:
-    imgs_gray = [imread_gray(p) for p in paths]
+    norm = bool(app_cfg.get("normalize", True))
+    scale_minmax = app_cfg.get("scale_minmax")
+    imgs_gray = [imread_gray(p, normalize=norm, scale_minmax=scale_minmax) for p in paths]
     H, W = imgs_gray[0].shape[:2]
 
     # Determine direction and starting reference frame

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -48,6 +48,8 @@ class AppParams:
     save_intermediates: bool = True
     use_difference_for_seg: bool = False
     use_file_timestamps: bool = True
+    normalize: bool = True
+    scale_minmax: Optional[tuple[int, int]] = None
     presets_path: Optional[str] = None
     last_folder: str | None = None
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,9 @@ def test_settings_persist(tmp_path):
     win.overlay_ref_cb.setChecked(False)
     win.overlay_mov_cb.setChecked(False)
     win.alpha_slider.setValue(75)
+    win.norm_cb.setChecked(True)
+    win.scale_min.setValue(5)
+    win.scale_max.setValue(100)
     win.close()
     app.processEvents()
 
@@ -48,6 +51,9 @@ def test_settings_persist(tmp_path):
     assert not win2.overlay_ref_cb.isChecked()
     assert not win2.overlay_mov_cb.isChecked()
     assert win2.alpha_slider.value() == 75
+    assert win2.norm_cb.isChecked()
+    assert win2.scale_min.value() == 5
+    assert win2.scale_max.value() == 100
     win2.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- add optional normalization and fixed min/max scaling to `imread_gray`
- expose normalization controls in app settings and UI
- propagate normalization options through processing pipeline and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c063c64a248324bc05bda7ea2780b5