### PR TITLE
Add optional background rescaling control

### DIFF
--- a/app/core/background.py
+++ b/app/core/background.py
@@ -10,8 +10,33 @@ def estimate_temporal_background(frames: list[np.ndarray], n_early: int=5) -> np
     med = np.median(stack, axis=0).astype(np.uint8)
     return med
 
-def normalize_background(img: np.ndarray, bg: np.ndarray) -> np.ndarray:
-    # Simple illumination correction: subtract, then rescale
-    diff = cv2.subtract(img, bg)
-    diff = cv2.normalize(diff, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
-    return diff
+def normalize_background(img: np.ndarray, bg: np.ndarray, rescale: bool = True) -> np.ndarray:
+    """Subtract a background image and optionally rescale the result.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Input image.
+    bg : np.ndarray
+        Background image to subtract.
+    rescale : bool, optional
+        If ``True`` (default), the difference image is rescaled to the full
+        ``[0, 255]`` range using :func:`cv2.normalize`. When ``False``, the
+        raw difference is used and negative values are clipped to ``0``.
+
+    Returns
+    -------
+    np.ndarray
+        Background corrected image as ``uint8``.
+    """
+
+    # Compute difference in a signed type so negatives can be detected.
+    diff = img.astype(np.float32) - bg.astype(np.float32)
+
+    if rescale:
+        diff = cv2.normalize(diff, None, 0, 255, cv2.NORM_MINMAX)
+    else:
+        # When not rescaling, simply clamp negative values to zero.
+        diff = np.clip(diff, 0, None)
+
+    return diff.astype(np.uint8)

--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -34,7 +34,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
     # Background normalization using early frames
     bg = estimate_temporal_background(imgs_gray, n_early=5)
-    imgs_norm = [normalize_background(g, bg) for g in imgs_gray]
+    rescale_bg = bool(app_cfg.get("rescale_background", True))
+    imgs_norm = [normalize_background(g, bg, rescale=rescale_bg) for g in imgs_gray]
     gauss_sigma = float(reg_cfg.get("gauss_blur_sigma", 1.0))
     clahe_clip = float(reg_cfg.get("clahe_clip", 2.0))
     clahe_grid = int(reg_cfg.get("clahe_grid", 8))

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -49,6 +49,7 @@ class AppParams:
     use_difference_for_seg: bool = False
     use_file_timestamps: bool = True
     normalize: bool = True
+    rescale_background: bool = True
     scale_minmax: Optional[tuple[int, int]] = None
     presets_path: Optional[str] = None
     last_folder: str | None = None

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -96,9 +96,12 @@ class MainWindow(QMainWindow):
         else:
             self.scale_min.setValue(0)
             self.scale_max.setValue(0)
+        self.rescale_cb = QCheckBox("Rescale background subtraction")
+        self.rescale_cb.setChecked(self.app.rescale_background)
         intensity_form.addRow(self.norm_cb)
         intensity_form.addRow("Min", self.scale_min)
         intensity_form.addRow("Max", self.scale_max)
+        intensity_form.addRow(self.rescale_cb)
         controls.addWidget(intensity_group)
         self.scale_min.setEnabled(self.norm_cb.isChecked())
         self.scale_max.setEnabled(self.norm_cb.isChecked())
@@ -106,9 +109,11 @@ class MainWindow(QMainWindow):
         self.norm_cb.toggled.connect(self._persist_settings)
         self.scale_min.valueChanged.connect(self._persist_settings)
         self.scale_max.valueChanged.connect(self._persist_settings)
+        self.rescale_cb.toggled.connect(self._persist_settings)
         self.norm_cb.toggled.connect(self._on_params_changed)
         self.scale_min.valueChanged.connect(self._on_params_changed)
         self.scale_max.valueChanged.connect(self._on_params_changed)
+        self.rescale_cb.toggled.connect(self._on_params_changed)
 
         # Registration params
         reg_group = QGroupBox("Registration")
@@ -404,6 +409,7 @@ class MainWindow(QMainWindow):
                         minutes_between_frames=self.dt_min.value(),
                         use_file_timestamps=self.use_ts.isChecked(),
                         normalize=self.norm_cb.isChecked(),
+                        rescale_background=self.rescale_cb.isChecked(),
                         scale_minmax=scale_minmax,
                         show_ref_overlay=self.overlay_ref_cb.isChecked(),
                         show_mov_overlay=self.overlay_mov_cb.isChecked(),
@@ -679,7 +685,9 @@ class MainWindow(QMainWindow):
                        remove_objects_smaller_px=seg.remove_objects_smaller_px, remove_holes_smaller_px=seg.remove_holes_smaller_px)
         app_cfg = dict(direction=app.direction,
                        use_difference_for_seg=False, save_intermediates=True,
-                       normalize=app.normalize, scale_minmax=app.scale_minmax)
+                       normalize=app.normalize,
+                       rescale_background=app.rescale_background,
+                       scale_minmax=app.scale_minmax)
 
         # timestamps if requested
         if app.use_file_timestamps:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,6 +33,7 @@ def test_settings_persist(tmp_path):
     win.norm_cb.setChecked(True)
     win.scale_min.setValue(5)
     win.scale_max.setValue(100)
+    win.rescale_cb.setChecked(False)
     win.close()
     app.processEvents()
 
@@ -54,6 +55,7 @@ def test_settings_persist(tmp_path):
     assert win2.norm_cb.isChecked()
     assert win2.scale_min.value() == 5
     assert win2.scale_max.value() == 100
+    assert not win2.rescale_cb.isChecked()
     win2.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- Add `rescale` flag to `normalize_background` to allow skipping intensity rescaling
- Plumb rescale option through processing pipeline and app settings/UI
- Test configuration persistence for new rescaling option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06589fb808324a74290e708d081fa