### PR TITLE
feat: add customizable overlay modes

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -43,6 +43,9 @@ class AppParams:
     show_ref_overlay: bool = True
     show_mov_overlay: bool = True
     overlay_opacity: int = 50
+    overlay_mode: str = "magenta-green"
+    overlay_ref_color: tuple[int, int, int] = (0, 255, 0)
+    overlay_mov_color: tuple[int, int, int] = (255, 0, 255)
     save_jpg_quality: int = 95
     save_png: bool = False
     save_intermediates: bool = True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,7 @@ def test_settings_persist(tmp_path):
     win.overlay_ref_cb.setChecked(False)
     win.overlay_mov_cb.setChecked(False)
     win.alpha_slider.setValue(75)
+    win.overlay_mode_combo.setCurrentText("grayscale")
     win.norm_cb.setChecked(True)
     win.scale_min.setValue(5)
     win.scale_max.setValue(100)
@@ -52,6 +53,7 @@ def test_settings_persist(tmp_path):
     assert not win2.overlay_ref_cb.isChecked()
     assert not win2.overlay_mov_cb.isChecked()
     assert win2.alpha_slider.value() == 75
+    assert win2.overlay_mode_combo.currentText() == "grayscale"
     assert win2.norm_cb.isChecked()
     assert win2.scale_min.value() == 5
     assert win2.scale_max.value() == 100


### PR DESCRIPTION
## Summary
- add overlay mode and color fields to AppParams
- expose overlay scheme controls in the main window and recolor overlays accordingly
- persist overlay mode in settings tests

## Testing
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68c066e354c083248a2be935e6ae6f74