### PR TITLE
Improve registration error handling

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -675,12 +675,14 @@ class MainWindow(QMainWindow):
             ref_img = preprocess(ref_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
             mov_img = preprocess(mov_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
             if reg.method.upper() == "ORB":
-                _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
-                                            orb_features=reg.orb_features,
-                                            match_ratio=reg.match_ratio)
+                success, _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
+                                                    orb_features=reg.orb_features,
+                                                    match_ratio=reg.match_ratio)
             else:
-                _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
-                                            max_iters=reg.max_iters, eps=reg.eps)
+                success, _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
+                                                    max_iters=reg.max_iters, eps=reg.eps)
+            if not success:
+                raise RuntimeError("Registration failed")
             self._reg_ref = ref_img
             self._reg_warp = warped
             self._current_preview = "registration"
@@ -726,12 +728,14 @@ class MainWindow(QMainWindow):
                 ref_img = preprocess(ref_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
                 mov_img = preprocess(mov_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
                 if reg.method.upper() == "ORB":
-                    _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
-                                                orb_features=reg.orb_features,
-                                                match_ratio=reg.match_ratio)
+                    success, _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
+                                                        orb_features=reg.orb_features,
+                                                        match_ratio=reg.match_ratio)
                 else:
-                    _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
-                                                max_iters=reg.max_iters, eps=reg.eps)
+                    success, _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
+                                                        max_iters=reg.max_iters, eps=reg.eps)
+                if not success:
+                    raise RuntimeError("Registration failed")
                 self._reg_ref = ref_img
                 self._reg_warp = warped
 

--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -43,7 +43,7 @@ def test_orb_parameters_affect_registration(monkeypatch):
 
     ref = np.zeros((5, 5), dtype=np.uint8)
     mov = np.zeros((5, 5), dtype=np.uint8)
-    H_good, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
-    assert H_good.shape == (3, 3)
-    H_bad, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
+    success_good, H_good, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
+    assert success_good and H_good.shape == (3, 3)
+    success_bad, H_bad, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
     assert H_bad.shape == (2, 3)


### PR DESCRIPTION
## Summary
- log OpenCV ECC exceptions and return a success flag from registration helpers
- propagate registration failures to callers and surface issues in UI
- adjust ORB registration tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0772ae00883249d4b09281d4a238b