### PR TITLE
Add flexible ORB models with ECC passthrough

### DIFF
--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -46,4 +46,4 @@ def test_orb_parameters_affect_registration(monkeypatch):
     success_good, H_good, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
     assert success_good and H_good.shape == (3, 3)
     success_bad, H_bad, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
-    assert H_bad.shape == (2, 3)
+    assert H_bad.shape == (3, 3)

--- a/tests/test_registration_models.py
+++ b/tests/test_registration_models.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+import numpy as np
+import cv2
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.registration import register_orb
+
+
+def dummy_keypoints(n):
+    return [cv2.KeyPoint(float(i), float(i), 1) for i in range(n)]
+
+
+def setup_orb(monkeypatch):
+    class DummyORB:
+        def detectAndCompute(self, img, mask):
+            kps = dummy_keypoints(10)
+            desc = np.zeros((10, 32), dtype=np.uint8)
+            return kps, desc
+    monkeypatch.setattr(cv2, "ORB_create", lambda n: DummyORB())
+
+    class DummyMatcher:
+        def knnMatch(self, d1, d2, k=2):
+            class Match:
+                def __init__(self, dist, q=0, t=0):
+                    self.distance = dist
+                    self.queryIdx = q
+                    self.trainIdx = t
+            m = Match(5)
+            n = Match(10)
+            return [(m, n)] * 10
+    monkeypatch.setattr(cv2, "BFMatcher", lambda norm, crossCheck: DummyMatcher())
+
+    monkeypatch.setattr(cv2, "warpAffine", lambda img, M, dsize, flags=0: img)
+    monkeypatch.setattr(cv2, "warpPerspective", lambda img, M, dsize, flags=0: img)
+    monkeypatch.setattr(cv2, "findHomography", lambda dst, src, method, ransac: (np.eye(3, dtype=np.float32), None))
+
+    def fake_estimate(dst, src, method=cv2.RANSAC, ransacReprojThreshold=3.0):
+        return np.array([[0.5, 0.1, 2.0], [-0.1, 0.5, 3.0]], dtype=np.float32), None
+    monkeypatch.setattr(cv2, "estimateAffine2D", fake_estimate)
+
+
+def test_register_orb_models(monkeypatch):
+    setup_orb(monkeypatch)
+    ref = np.zeros((5, 5), dtype=np.uint8)
+    mov = np.zeros((5, 5), dtype=np.uint8)
+
+    _, H, _, _ = register_orb(ref, mov, model="homography")
+    assert H.shape == (3, 3)
+
+    _, A, _, _ = register_orb(ref, mov, model="affine")
+    assert A.shape == (2, 3)
+
+    _, E, _, _ = register_orb(ref, mov, model="euclidean")
+    assert E.shape == (2, 3)
+    R = E[:, :2]
+    assert np.allclose(R.T @ R, np.eye(2), atol=1e-6)
+
+    _, T, _, _ = register_orb(ref, mov, model="translation")
+    assert T.shape == (2, 3)
+    assert np.allclose(T[:, :2], np.eye(2), atol=1e-6)


### PR DESCRIPTION
## Summary
- Support homography, affine, euclidean, and translation models in ORB-based registration
- Propagate requested model to ECC fallback
- Add comprehensive tests for ORB registration models and adjust existing test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c079905c1c83248ed7ccb43efd49bf