### PR TITLE
Validate ORB homography and flag ECC fallback

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -92,13 +92,15 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             ref_gray = prev_full[bbox_y:bbox_y + bbox_h, bbox_x:bbox_x + bbox_w]
 
             if reg_cfg.get("method", "ECC").upper() == "ORB":
-                success, W_step, warped, valid_mask = register_orb(
+                success, W_step, warped, valid_mask, fb = register_orb(
                     ref_gray,
                     g_norm,
                     model=reg_cfg.get("model", "homography"),
                     orb_features=int(reg_cfg.get("orb_features", 4000)),
                     match_ratio=float(reg_cfg.get("match_ratio", 0.75)),
                 )
+                if fb:
+                    logging.warning("ORB registration fell back to ECC at frame %d", k)
             else:
                 success, W_step, warped, valid_mask = register_ecc(
                     ref_gray,

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -675,9 +675,11 @@ class MainWindow(QMainWindow):
             ref_img = preprocess(ref_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
             mov_img = preprocess(mov_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
             if reg.method.upper() == "ORB":
-                success, _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
-                                                    orb_features=reg.orb_features,
-                                                    match_ratio=reg.match_ratio)
+                success, _, warped, _, fb = register_orb(ref_img, mov_img, model=reg.model,
+                                                         orb_features=reg.orb_features,
+                                                         match_ratio=reg.match_ratio)
+                if fb:
+                    self.status_label.setText("ORB fell back to ECC for registration.")
             else:
                 success, _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
                                                     max_iters=reg.max_iters, eps=reg.eps)
@@ -728,9 +730,11 @@ class MainWindow(QMainWindow):
                 ref_img = preprocess(ref_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
                 mov_img = preprocess(mov_img, reg.gauss_blur_sigma, reg.clahe_clip, reg.clahe_grid)
                 if reg.method.upper() == "ORB":
-                    success, _, warped, _ = register_orb(ref_img, mov_img, model=reg.model,
-                                                        orb_features=reg.orb_features,
-                                                        match_ratio=reg.match_ratio)
+                    success, _, warped, _, fb = register_orb(ref_img, mov_img, model=reg.model,
+                                                             orb_features=reg.orb_features,
+                                                             match_ratio=reg.match_ratio)
+                    if fb:
+                        self.status_label.setText("ORB fell back to ECC for registration.")
                 else:
                     success, _, warped, _ = register_ecc(ref_img, mov_img, model=reg.model,
                                                         max_iters=reg.max_iters, eps=reg.eps)

--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -37,13 +37,13 @@ def test_orb_parameters_affect_registration(monkeypatch):
 
     monkeypatch.setattr(cv2, "ORB_create", fake_orb_create)
     monkeypatch.setattr(cv2, "BFMatcher", fake_bfmatcher)
-    monkeypatch.setattr(cv2, "findHomography", lambda dst, src, method, ransac: (np.eye(3, dtype=np.float32), None))
+    monkeypatch.setattr(cv2, "findHomography", lambda dst, src, method, ransac: (np.eye(3, dtype=np.float32), np.ones((10,1), dtype=np.uint8)))
     monkeypatch.setattr(cv2, "warpPerspective", lambda img, H, dsize, flags=0: img)
     monkeypatch.setattr(cv2, "warpAffine", lambda img, M, dsize, flags=0: img)
 
     ref = np.zeros((5, 5), dtype=np.uint8)
     mov = np.zeros((5, 5), dtype=np.uint8)
-    success_good, H_good, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
-    assert success_good and H_good.shape == (3, 3)
-    success_bad, H_bad, _, _ = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
-    assert H_bad.shape == (3, 3)
+    success_good, H_good, _, _, fb_good = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
+    assert success_good and H_good.shape == (3, 3) and not fb_good
+    success_bad, H_bad, _, _, fb_bad = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
+    assert H_bad.shape == (3, 3) and fb_bad


### PR DESCRIPTION
## Summary
- verify ORB homography with determinant and inlier ratio checks
- fall back to ECC registration when homography fails, returning a flag
- update tests and callers to handle fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c07b14e2f48324b3ade76474abad16