### PR TITLE
Add configurable ECC fallback for ORB registration

### DIFF
--- a/tests/test_orb_ecc_integration.py
+++ b/tests/test_orb_ecc_integration.py
@@ -10,7 +10,7 @@ import app.core.registration as reg
 def test_orb_ecc_uses_orb_init(monkeypatch):
     W_orb = np.array([[1, 0, 2], [0, 1, 3], [0, 0, 1]], dtype=np.float32)
 
-    def fake_register_orb(ref, mov, model="affine", orb_features=4000, match_ratio=0.75):
+    def fake_register_orb(ref, mov, model="affine", orb_features=4000, match_ratio=0.75, fallback_model="affine"):
         return True, W_orb.copy(), mov, np.ones_like(mov, dtype=np.uint8), False
 
     captured = {}

--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -46,4 +46,4 @@ def test_orb_parameters_affect_registration(monkeypatch):
     success_good, H_good, _, _, fb_good = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
     assert success_good and H_good.shape == (3, 3) and not fb_good
     success_bad, H_bad, _, _, fb_bad = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
-    assert H_bad.shape == (3, 3) and fb_bad
+    assert H_bad.shape == (2, 3) and fb_bad


### PR DESCRIPTION
## Summary
- allow `register_orb` to accept a `fallback_model` used when ORB fails
- propagate `fallback_model` through `register_orb_ecc`
- adjust tests and add coverage for the new fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09d2ede988324976e0dce62e287da