### PR TITLE
Make background subtraction optional

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -33,10 +33,12 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         step = -1
         k_range = range(ref_idx, -1, -1)
 
-    # Background normalization using early frames
-    bg = estimate_temporal_background(imgs_gray, n_early=5)
-    rescale_bg = bool(app_cfg.get("rescale_background", True))
-    imgs_norm = [normalize_background(g, bg, rescale=rescale_bg) for g in imgs_gray]
+    # Optionally subtract a temporal background using early frames
+    if app_cfg.get("subtract_background", False):
+        bg = estimate_temporal_background(imgs_gray, n_early=5)
+        imgs_norm = [normalize_background(g, bg) for g in imgs_gray]
+    else:
+        imgs_norm = imgs_gray
     gauss_sigma = float(reg_cfg.get("gauss_blur_sigma", 1.0))
     clahe_clip = float(reg_cfg.get("clahe_clip", 2.0))
     clahe_grid = int(reg_cfg.get("clahe_grid", 8))

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -53,7 +53,7 @@ class AppParams:
     use_difference_for_seg: bool = False
     use_file_timestamps: bool = True
     normalize: bool = True
-    rescale_background: bool = True
+    subtract_background: bool = False
     scale_minmax: Optional[tuple[int, int]] = None
     presets_path: Optional[str] = None
     last_folder: str | None = None

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -123,15 +123,15 @@ class MainWindow(QMainWindow):
         else:
             self.scale_min.setValue(0)
             self.scale_max.setValue(0)
-        self.rescale_cb = QCheckBox("Rescale background subtraction")
-        self.rescale_cb.setChecked(self.app.rescale_background)
+        self.bg_sub_cb = QCheckBox("Subtract background")
+        self.bg_sub_cb.setChecked(self.app.subtract_background)
         intensity_form.addRow(self.norm_cb)
         intensity_form.addRow("Min", self.scale_min)
         intensity_form.addRow("Max", self.scale_max)
         self.auto_scale_btn = QPushButton("Auto min/max")
         self.auto_scale_btn.clicked.connect(self._auto_scale_minmax)
         intensity_form.addRow(self.auto_scale_btn)
-        intensity_form.addRow(self.rescale_cb)
+        intensity_form.addRow(self.bg_sub_cb)
         controls.addWidget(intensity_group)
         self.scale_min.setEnabled(self.norm_cb.isChecked())
         self.scale_max.setEnabled(self.norm_cb.isChecked())
@@ -139,11 +139,11 @@ class MainWindow(QMainWindow):
         self.norm_cb.toggled.connect(self._persist_settings)
         self.scale_min.valueChanged.connect(self._persist_settings)
         self.scale_max.valueChanged.connect(self._persist_settings)
-        self.rescale_cb.toggled.connect(self._persist_settings)
+        self.bg_sub_cb.toggled.connect(self._persist_settings)
         self.norm_cb.toggled.connect(self._on_params_changed)
         self.scale_min.valueChanged.connect(self._on_params_changed)
         self.scale_max.valueChanged.connect(self._on_params_changed)
-        self.rescale_cb.toggled.connect(self._on_params_changed)
+        self.bg_sub_cb.toggled.connect(self._on_params_changed)
 
         # Registration params
         reg_group = QGroupBox("Registration")
@@ -482,7 +482,7 @@ class MainWindow(QMainWindow):
                         minutes_between_frames=self.dt_min.value(),
                         use_file_timestamps=self.use_ts.isChecked(),
                         normalize=self.norm_cb.isChecked(),
-                        rescale_background=self.rescale_cb.isChecked(),
+                        subtract_background=self.bg_sub_cb.isChecked(),
                         scale_minmax=scale_minmax,
                         show_ref_overlay=self.overlay_ref_cb.isChecked(),
                         show_mov_overlay=self.overlay_mov_cb.isChecked(),
@@ -811,7 +811,7 @@ class MainWindow(QMainWindow):
         app_cfg = dict(direction=app.direction,
                        use_difference_for_seg=False, save_intermediates=True,
                        normalize=app.normalize,
-                       rescale_background=app.rescale_background,
+                       subtract_background=app.subtract_background,
                        scale_minmax=app.scale_minmax)
 
         # timestamps if requested

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,7 +37,7 @@ def test_settings_persist(tmp_path):
     win.norm_cb.setChecked(True)
     win.scale_min.setValue(5)
     win.scale_max.setValue(100)
-    win.rescale_cb.setChecked(False)
+    win.bg_sub_cb.setChecked(True)
     win.close()
     app.processEvents()
 
@@ -63,7 +63,7 @@ def test_settings_persist(tmp_path):
     assert win2.norm_cb.isChecked()
     assert win2.scale_min.value() == 5
     assert win2.scale_max.value() == 100
-    assert not win2.rescale_cb.isChecked()
+    assert win2.bg_sub_cb.isChecked()
     win2.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- make temporal background subtraction optional and default-off
- remove `rescale_background` setting and UI
- persist new `subtract_background` flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a128a33083248c28c28c22be7b5c