### PR TITLE
Add configurable ORB thresholds and ECC fallback toggle

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -101,6 +101,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                     model=reg_cfg.get("model", "homography"),
                     orb_features=int(reg_cfg.get("orb_features", 4000)),
                     match_ratio=float(reg_cfg.get("match_ratio", 0.75)),
+                    min_keypoints=int(reg_cfg.get("min_keypoints", 8)),
+                    min_matches=int(reg_cfg.get("min_matches", 8)),
+                    use_ecc_fallback=bool(reg_cfg.get("use_ecc_fallback", True)),
                 )
                 if fb:
                     logging.warning("ORB registration fell back to ECC at frame %d", k)
@@ -116,6 +119,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                     eps=float(reg_cfg.get("eps", 1e-6)),
                     orb_features=int(reg_cfg.get("orb_features", 4000)),
                     match_ratio=float(reg_cfg.get("match_ratio", 0.75)),
+                    min_keypoints=int(reg_cfg.get("min_keypoints", 8)),
+                    min_matches=int(reg_cfg.get("min_matches", 8)),
+                    use_ecc_fallback=bool(reg_cfg.get("use_ecc_fallback", True)),
                     mask=ecc_mask if reg_cfg.get("use_masked_ecc", True) else None,
                 )
                 if not success:

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -22,6 +22,9 @@ class RegParams:
     use_masked_ecc: bool = True
     orb_features: int = 4000
     match_ratio: float = 0.75
+    min_keypoints: int = 8
+    min_matches: int = 8
+    use_ecc_fallback: bool = True
 
 @dataclass
 class SegParams:

--- a/tests/test_orb_ecc_integration.py
+++ b/tests/test_orb_ecc_integration.py
@@ -10,7 +10,9 @@ import app.core.registration as reg
 def test_orb_ecc_uses_orb_init(monkeypatch):
     W_orb = np.array([[1, 0, 2], [0, 1, 3], [0, 0, 1]], dtype=np.float32)
 
-    def fake_register_orb(ref, mov, model="affine", orb_features=4000, match_ratio=0.75, fallback_model="affine"):
+    def fake_register_orb(ref, mov, model="affine", orb_features=4000, match_ratio=0.75,
+                          fallback_model="affine", *, min_keypoints=8, min_matches=8,
+                          use_ecc_fallback=True):
         return True, W_orb.copy(), mov, np.ones_like(mov, dtype=np.uint8), False
 
     captured = {}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,9 @@ def test_settings_persist(tmp_path):
     win.use_masked.setChecked(False)
     win.orb_features.setValue(123)
     win.match_ratio.setValue(0.55)
+    win.min_keypoints.setValue(5)
+    win.min_matches.setValue(6)
+    win.use_ecc_fallback.setChecked(False)
     win.seg_method.setCurrentText("manual")
     win.dir_combo.setCurrentText("first-to-last")
     win.overlay_ref_cb.setChecked(False)
@@ -54,6 +57,9 @@ def test_settings_persist(tmp_path):
     assert not win2.use_masked.isChecked()
     assert win2.orb_features.value() == 123
     assert win2.match_ratio.value() == 0.55
+    assert win2.min_keypoints.value() == 5
+    assert win2.min_matches.value() == 6
+    assert not win2.use_ecc_fallback.isChecked()
     assert win2.seg_method.currentText() == "manual"
     assert win2.dir_combo.currentText() == "first-to-last"
     assert not win2.overlay_ref_cb.isChecked()


### PR DESCRIPTION
## Summary
- Expose minimum keypoint/match thresholds and ECC fallback toggle for ORB registration
- Thread new registration options through processing pipeline and PyQt UI
- Extend registration settings dataclass with new ORB parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a4cd67f483248fbdca3481f686ff