### PR TITLE
Validate pipeline direction in UI

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -831,6 +831,15 @@ class MainWindow(QMainWindow):
             return
 
         reg, seg, app = self._persist_settings()
+        # Guard against invalid direction values
+        if app.direction not in ("first-to-last", "last-to-first"):
+            QMessageBox.critical(
+                self,
+                "Invalid Direction",
+                f"Analysis direction must be 'first-to-last' or 'last-to-first'. Got: {app.direction}",
+            )
+            return
+
         # Build slim dicts for worker
         reg_cfg = dict(method=reg.method, model=reg.model, max_iters=reg.max_iters,
                        eps=reg.eps, use_masked_ecc=reg.use_masked_ecc,

--- a/tests/test_invalid_direction_ui.py
+++ b/tests/test_invalid_direction_ui.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+import sys
+from PyQt6.QtWidgets import QApplication, QMessageBox
+from PyQt6.QtCore import QSettings
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.ui.main_window import MainWindow
+from app.models.config import RegParams, SegParams, AppParams
+
+
+def test_invalid_direction_aborts(tmp_path, monkeypatch):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.paths = [tmp_path / "dummy.png"]
+
+    reg = RegParams()
+    seg = SegParams()
+    app_params = AppParams(direction="invalid")
+    monkeypatch.setattr(win, "_persist_settings", lambda *a, **k: (reg, seg, app_params))
+
+    captured = {}
+
+    def fake_critical(parent, title, text):
+        captured["title"] = title
+        captured["text"] = text
+
+    monkeypatch.setattr(QMessageBox, "critical", fake_critical)
+
+    win._run_pipeline()
+
+    assert captured["title"] == "Invalid Direction"
+    assert "invalid" in captured["text"]
+    assert not hasattr(win, "worker")
+
+    win.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- add guard in `_run_pipeline` to validate analysis direction and show error when invalid
- test that invalid direction aborts pipeline and displays message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b0df34508324b3557f6cef38cbba