### PR TITLE
Expose ORB keypoint counts in registration UI

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -111,7 +111,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
             method = reg_cfg.get("method", "ECC").upper()
             if method == "ORB":
-                success, W_step, warped, valid_mask, fb = register_orb(
+                success, W_step, warped, valid_mask, fb, _, _ = register_orb(
                     ref_gray,
                     g_norm,
                     model=reg_cfg.get("model", "homography"),
@@ -127,7 +127,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                     logging.warning("Registration failed at frame %d", k)
                     continue
             elif method == "ORB+ECC":
-                success, W_step, warped, valid_mask = register_orb_ecc(
+                success, W_step, warped, valid_mask, _, _ = register_orb_ecc(
                     ref_gray,
                     g_norm,
                     model=reg_cfg.get("model", "affine"),

--- a/tests/test_orb_ecc_integration.py
+++ b/tests/test_orb_ecc_integration.py
@@ -13,7 +13,7 @@ def test_orb_ecc_uses_orb_init(monkeypatch):
     def fake_register_orb(ref, mov, model="affine", orb_features=4000, match_ratio=0.75,
                           fallback_model="affine", *, min_keypoints=8, min_matches=8,
                           use_ecc_fallback=True):
-        return True, W_orb.copy(), mov, np.ones_like(mov, dtype=np.uint8), False
+        return True, W_orb.copy(), mov, np.ones_like(mov, dtype=np.uint8), False, 12, 34
 
     captured = {}
 
@@ -32,7 +32,7 @@ def test_orb_ecc_uses_orb_init(monkeypatch):
     ref = np.zeros((10, 10), dtype=np.uint8)
     mov = np.zeros((10, 10), dtype=np.uint8)
 
-    success, W_refined, _, _ = reg.register_orb_ecc(ref, mov, model="homography", max_iters=10, eps=1e-4)
+    success, W_refined, _, _, n1, n2 = reg.register_orb_ecc(ref, mov, model="homography", max_iters=10, eps=1e-4)
 
     assert success
     assert np.allclose(captured["init"], W_orb)
@@ -40,3 +40,4 @@ def test_orb_ecc_uses_orb_init(monkeypatch):
     expected[0, 2] += 1
     expected[1, 2] += 1
     assert np.allclose(W_refined, expected)
+    assert n1 == 12 and n2 == 34

--- a/tests/test_orb_params.py
+++ b/tests/test_orb_params.py
@@ -43,7 +43,9 @@ def test_orb_parameters_affect_registration(monkeypatch):
 
     ref = np.zeros((5, 5), dtype=np.uint8)
     mov = np.zeros((5, 5), dtype=np.uint8)
-    success_good, H_good, _, _, fb_good = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
+    success_good, H_good, _, _, fb_good, n1_good, n2_good = register_orb(ref, mov, orb_features=500, match_ratio=0.7)
     assert success_good and H_good.shape == (3, 3) and not fb_good
-    success_bad, H_bad, _, _, fb_bad = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
+    assert n1_good == 10 and n2_good == 10
+    success_bad, H_bad, _, _, fb_bad, n1_bad, n2_bad = register_orb(ref, mov, orb_features=500, match_ratio=0.4)
     assert H_bad.shape == (2, 3) and fb_bad
+    assert n1_bad == 10 and n2_bad == 10

--- a/tests/test_registration_models.py
+++ b/tests/test_registration_models.py
@@ -45,18 +45,19 @@ def test_register_orb_models(monkeypatch):
     ref = np.zeros((5, 5), dtype=np.uint8)
     mov = np.zeros((5, 5), dtype=np.uint8)
 
-    _, H, _, _, fb = register_orb(ref, mov, model="homography")
+    _, H, _, _, fb, n1, n2 = register_orb(ref, mov, model="homography")
     assert H.shape == (3, 3) and not fb
+    assert n1 == 10 and n2 == 10
 
-    _, A, _, _, fb = register_orb(ref, mov, model="affine")
+    _, A, _, _, fb, _, _ = register_orb(ref, mov, model="affine")
     assert A.shape == (2, 3) and not fb
 
-    _, E, _, _, fb = register_orb(ref, mov, model="euclidean")
+    _, E, _, _, fb, _, _ = register_orb(ref, mov, model="euclidean")
     assert E.shape == (2, 3) and not fb
     R = E[:, :2]
     assert np.allclose(R.T @ R, np.eye(2), atol=1e-6)
 
-    _, T, _, _, fb = register_orb(ref, mov, model="translation")
+    _, T, _, _, fb, _, _ = register_orb(ref, mov, model="translation")
     assert T.shape == (2, 3) and not fb
     assert np.allclose(T[:, :2], np.eye(2), atol=1e-6)
 
@@ -69,7 +70,7 @@ def test_orb_homography_fallback(monkeypatch):
     monkeypatch.setattr(reg, "register_ecc", lambda ref, mov, model='homography': (True, np.eye(3, dtype=np.float32), mov, np.ones_like(ref, dtype=np.uint8)))
     ref = np.zeros((5,5), dtype=np.uint8)
     mov = np.zeros((5,5), dtype=np.uint8)
-    success, _, _, _, fb = reg.register_orb(ref, mov, model="homography")
+    success, _, _, _, fb, _, _ = reg.register_orb(ref, mov, model="homography")
     assert success and fb
 
 
@@ -93,6 +94,6 @@ def test_register_orb_fallback_model(monkeypatch):
     ref = np.zeros((5, 5), dtype=np.uint8)
     mov = np.zeros((5, 5), dtype=np.uint8)
 
-    reg.register_orb(ref, mov, model="homography", fallback_model="translation")
+    _, _, _, _, _, _, _ = reg.register_orb(ref, mov, model="homography", fallback_model="translation")
 
     assert captured["model"] == "translation"


### PR DESCRIPTION
## Summary
- return ORB keypoint counts from `register_orb` and `register_orb_ecc`
- show detected keypoint counts in registration preview UI
- update tests for new registration signatures

## Testing
- `pytest tests/test_orb_params.py tests/test_registration_models.py tests/test_orb_ecc_integration.py -q`
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: segmentation fault due to PyQt GUI issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b43d527883249d23932ec8d2fd52