### PR TITLE
Configure application logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
+
+import logging
 import sys
+
 from PyQt6.QtWidgets import QApplication
+
 from .ui.main_window import MainWindow
 
+logger = logging.getLogger(__name__)
+
 def main():
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    logger.debug("Application initialized")
+
     app = QApplication(sys.argv)
     w = MainWindow()
     w.show()


### PR DESCRIPTION
## Summary
- initialize logging configuration in application entry point for debugging
- log message when application initializes

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14bcd06088324b84a25a74bcaa4c3