### PR TITLE
Add logging to pipeline worker

### DIFF
--- a/app/workers/pipeline_worker.py
+++ b/app/workers/pipeline_worker.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
-from PyQt6.QtCore import QObject, pyqtSignal, QThread
+import logging
 from pathlib import Path
 from typing import List, Dict, Any
+
+from PyQt6.QtCore import QObject, pyqtSignal, QThread
+
 from ..core.processing import analyze_sequence
 from ..core.io_utils import ensure_dir
+
+logger = logging.getLogger(__name__)
 
 class PipelineWorker(QObject):
     progressed = pyqtSignal(int, int)  # current, total (reserved for future granular progress)
@@ -20,8 +25,20 @@ class PipelineWorker(QObject):
 
     def run(self):
         try:
+            logger.info("Starting processing for %d paths into %s", len(self.paths), self.out_dir)
             ensure_dir(self.out_dir)
+
+            total = len(self.paths)
+            self.progressed.emit(0, total)
+            logger.info("Progressed: %d/%d", 0, total)
+
             df = analyze_sequence(self.paths, self.reg_cfg, self.seg_cfg, self.app_cfg, self.out_dir)
+
+            self.progressed.emit(total, total)
+            logger.info("Progressed: %d/%d", total, total)
+
             self.finished.emit(str(self.out_dir))
+            logger.info("Processing finished: %s", self.out_dir)
         except Exception as e:
+            logger.exception("Processing failed")
             self.failed.emit(str(e))


### PR DESCRIPTION
## Summary
- Add module-level logger to `pipeline_worker.py`
- Log processing start, progress updates, completion, and exceptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c14f978f748324a48cf1a181115c54