### PR TITLE
Add optional mask saving with bounding box overlay

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -53,6 +53,7 @@ class AppParams:
     save_jpg_quality: int = 95
     save_png: bool = False
     save_intermediates: bool = True
+    save_masks: bool = False
     use_difference_for_seg: bool = False
     use_file_timestamps: bool = True
     normalize: bool = True


### PR DESCRIPTION
## Summary
- support `save_masks` config flag that writes ECC masks and overlays
- capture mask images for each frame and draw bounding boxes on original frames
- test that enabling `save_masks` produces mask files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15faf996c8324b1652c722c339aa2