### PR TITLE
Compute final crop rectangle post-registration

### DIFF
--- a/tests/test_crop_area_threshold.py
+++ b/tests/test_crop_area_threshold.py
@@ -58,7 +58,9 @@ def test_refuses_small_crop(tmp_path):
     out_dir = tmp_path / "out"
     df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    row = df[df["frame_index"] == 1].iloc[0]
-    overlap_area = int(row["overlap_w"]) * int(row["overlap_h"])
-    assert overlap_area == 25
+    row0 = df[df["frame_index"] == 0].iloc[0]
+    row1 = df[df["frame_index"] == 1].iloc[0]
+    for row in (row0, row1):
+        overlap_area = int(row["overlap_w"]) * int(row["overlap_h"])
+        assert overlap_area == 25
 

--- a/tests/test_per_frame_crop_rects.py
+++ b/tests/test_per_frame_crop_rects.py
@@ -69,8 +69,8 @@ def test_per_frame_crop_rectangles(tmp_path):
     row1 = df[df["frame_index"] == 1].iloc[0]
     row2 = df[df["frame_index"] == 2].iloc[0]
 
-    assert int(row1["overlap_w"]) == 50
-    assert int(row1["overlap_h"]) == 60
-    assert int(row2["overlap_w"]) == 70
-    assert int(row2["overlap_h"]) == 70
+    assert int(row1["overlap_w"]) == 30
+    assert int(row1["overlap_h"]) == 50
+    assert int(row2["overlap_w"]) == 30
+    assert int(row2["overlap_h"]) == 50
 


### PR DESCRIPTION
## Summary
- Compute the intersection of all registered frame extents and apply a uniform crop rectangle
- Simplify analyze_sequence by dropping progressive mask updates
- Update crop rectangle tests for new post-registration cropping behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e7cef3488324b948824a94a9cef9