### PR TITLE
Abort analysis on insufficient overlap

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -186,9 +186,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     overlap_area = w_f * h_f
     min_overlap = int(0.01 * H * W)
     if overlap_area < min_overlap:
-        logger.warning(
-            "Final overlap area %d below 1%% threshold %d", overlap_area, min_overlap
-        )
+        msg = f"Final overlap area {overlap_area} below 1% threshold {min_overlap}"
+        logger.error(msg)
+        raise ValueError(msg)
     if app_cfg.get("save_final_mask", False):
         cv2.imencode('.png', (final_mask * 255).astype(np.uint8))[1].tofile(
             str(out_dir / "final_mask.png")

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -953,7 +953,7 @@ class MainWindow(QMainWindow):
     def _on_failed(self, err: str):
         logger.error("Pipeline thread failed: %s", err)
         QMessageBox.critical(self, "Error", err)
-        self.status_label.setText("Failed.")
+        self.status_label.setText(f"Failed: {err}")
         self.thread.quit(); self.thread.wait()
 
     def closeEvent(self, event):

--- a/tests/test_crop_area_threshold.py
+++ b/tests/test_crop_area_threshold.py
@@ -1,7 +1,9 @@
 import numpy as np
+import numpy as np
 import cv2
 from pathlib import Path
 import sys
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -56,11 +58,7 @@ def test_refuses_small_crop(tmp_path):
     processing.register_ecc = fake_register
 
     out_dir = tmp_path / "out"
-    df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    row0 = df[df["frame_index"] == 0].iloc[0]
-    row1 = df[df["frame_index"] == 1].iloc[0]
-    for row in (row0, row1):
-        overlap_area = int(row["overlap_w"]) * int(row["overlap_h"])
-        assert overlap_area == 25
+    with pytest.raises(ValueError, match="overlap area"):
+        analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 

--- a/tests/test_low_overlap_error.py
+++ b/tests/test_low_overlap_error.py
@@ -1,8 +1,10 @@
 import numpy as np
+import numpy as np
+import numpy as np
 import cv2
 from pathlib import Path
 import sys
-import logging
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -18,7 +20,7 @@ def create_blank_images(tmp_path, n=2):
     return paths
 
 
-def test_warns_and_preserves_mask(tmp_path, caplog):
+def test_aborts_on_low_overlap(tmp_path):
     paths = create_blank_images(tmp_path, n=2)
 
     reg_cfg = {
@@ -57,10 +59,6 @@ def test_warns_and_preserves_mask(tmp_path, caplog):
     processing.register_ecc = fake_register
 
     out_dir = tmp_path / "out"
-    with caplog.at_level(logging.WARNING):
-        df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    assert any("overlap area" in rec.message for rec in caplog.records)
-    row = df[df["frame_index"] == 1].iloc[0]
-    assert row["overlap_w"] == 1
-    assert row["overlap_h"] == 1
+    with pytest.raises(ValueError, match="overlap area"):
+        analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)


### PR DESCRIPTION
## Summary
- Fail early in `analyze_sequence` when final overlap area falls below 1% of the frame
- Show detailed error message in the UI when processing fails
- Add tests covering low-overlap failure scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1eec4ce688324a93d608aa8b7fbb6