### PR TITLE
Raise error when all masks are empty during segmentation

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -228,6 +228,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     prev_bw = bw_ref
 
     ecc_mask = None
+    all_masks_empty = True
 
     for idx, k in enumerate(ordered_indices):
         logger.debug("Frame %d: segmentation phase", k)
@@ -262,6 +263,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                 str(bw_dir / f"{k:04d}_bw_mov_empty.png")
             )
         else:
+            all_masks_empty = False
             ecc_mask = bw_mov.copy()
             _save_mask(k, ecc_mask, x_k, y_k)
 
@@ -311,6 +313,11 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         prev_gray = warped
         prev_bw = np.zeros_like(prev_bw)
         prev_bw[y_k:y_k + h_k, x_k:x_k + w_k] = bw_mov
+
+    if all_masks_empty:
+        msg = "All segmentation masks were empty"
+        logger.error(msg)
+        raise ValueError(msg)
 
     df = pd.DataFrame(rows).sort_values("frame_index").reset_index(drop=True)
     summary_path = out_dir / "summary.csv"

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -952,7 +952,7 @@ class MainWindow(QMainWindow):
 
     def _on_failed(self, err: str):
         logger.error("Pipeline thread failed: %s", err)
-        QMessageBox.critical(self, "Error", err)
+        QMessageBox.critical(self, "Processing Error", f"{err}\nNo summary file was written.")
         self.status_label.setText(f"Failed: {err}")
         self.thread.quit(); self.thread.wait()
 

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -81,7 +81,7 @@ def test_last_to_first_registration_order(tmp_path, monkeypatch):
 
     monkeypatch.setattr(processing, "register_ecc", fake_register_ecc)
     monkeypatch.setattr(processing, "preprocess", lambda g, *a, **k: g)
-    monkeypatch.setattr(processing, "segment", lambda *a, **k: np.zeros_like(a[0], dtype=np.uint8))
+    monkeypatch.setattr(processing, "segment", lambda *a, **k: np.ones_like(a[0], dtype=np.uint8))
 
     reg_cfg = {
         "model": "affine",

--- a/tests/test_empty_mask_warning.py
+++ b/tests/test_empty_mask_warning.py
@@ -3,6 +3,7 @@ import cv2
 from pathlib import Path
 import sys
 import logging
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -69,3 +70,50 @@ def test_warns_and_skips_ecc_mask(tmp_path, caplog):
     assert empty_mask_path.exists()
     row = df[df["frame_index"] == 1].iloc[0]
     assert row["area_mov_px"] == 0
+
+
+def test_all_masks_empty_error(tmp_path):
+    paths = []
+    img = np.zeros((50, 50), dtype=np.uint8)
+    for i in range(2):
+        cv2.imwrite(str(tmp_path / f"img_{i}.png"), img)
+        paths.append(tmp_path / f"img_{i}.png")
+
+    reg_cfg = {
+        "model": "translation",
+        "max_iters": 10,
+        "gauss_blur_sigma": 0,
+        "clahe_clip": 0,
+        "clahe_grid": 8,
+        "use_masked_ecc": False,
+        "method": "ECC",
+        "eps": 1e-6,
+        "growth_factor": 1.0,
+        "initial_radius": 0,
+    }
+
+    seg_cfg = {
+        "method": "manual",
+        "manual_thresh": 1,
+        "invert": False,
+        "morph_open_radius": 0,
+        "morph_close_radius": 0,
+        "remove_objects_smaller_px": 0,
+        "remove_holes_smaller_px": 0,
+    }
+
+    app_cfg = {"direction": "first-to-last", "save_intermediates": False}
+
+    from app.core import processing
+
+    def fake_register(ref, mov, model="affine", **kwargs):
+        h, w = ref.shape
+        valid = np.ones((h, w), dtype=np.uint8)
+        return True, np.eye(3, dtype=np.float32), mov.copy(), valid
+
+    processing.register_ecc = fake_register
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(ValueError, match="All segmentation masks were empty"):
+        analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
+    assert not (out_dir / "summary.csv").exists()


### PR DESCRIPTION
## Summary
- Track if every segmentation mask is empty and raise a ValueError when that happens
- Show processing errors in the UI and warn that no summary file was written
- Add regression test for all-empty mask runs and adjust direction test to keep a non-empty mask

## Testing
- `pytest tests/test_empty_mask_warning.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f088f66c83248b813e908299ebe8