### PR TITLE
Allow tuning small-object filtering thresholds

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -17,7 +17,7 @@ def segment(gray: np.ndarray, method: str="otsu", invert: bool=True,
             manual_thresh: int=128, adaptive_block: int=51, adaptive_C: int=5,
             local_block: int=51,
             morph_open_radius: int=2, morph_close_radius: int=2,
-            remove_objects_smaller_px: int=64, remove_holes_smaller_px: int=64) -> np.ndarray:
+            remove_objects_smaller_px: int=0, remove_holes_smaller_px: int=0) -> np.ndarray:
     if method == "manual":
         proc = 255 - gray if invert else gray
         t = int(np.clip(manual_thresh, 0, 255))

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -33,8 +33,8 @@ class SegParams:
     adaptive_block: int = 51
     adaptive_C: int = 5
     local_block: int = 51
-    remove_holes_smaller_px: int = 64
-    remove_objects_smaller_px: int = 64
+    remove_holes_smaller_px: int = 0
+    remove_objects_smaller_px: int = 0
     morph_open_radius: int = 2
     morph_close_radius: int = 2
     invert: bool = True  # cells darker

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -320,6 +320,8 @@ class MainWindow(QMainWindow):
         self.seg_preview_btn.clicked.connect(self._preview_segmentation)
         seg_grid.addWidget(self.seg_preview_btn, 5, 0, 1, 4)
         controls.addWidget(seg_group)
+        self._add_help(self.rm_obj, "Remove connected components smaller than this area in pixels.")
+        self._add_help(self.rm_holes, "Fill holes smaller than this area in pixels.")
         self.seg_method.currentTextChanged.connect(self._persist_settings)
         self.invert.toggled.connect(self._persist_settings)
         self.manual_t.valueChanged.connect(self._persist_settings)

--- a/tests/test_small_object_preservation.py
+++ b/tests/test_small_object_preservation.py
@@ -1,0 +1,23 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment
+
+
+def test_small_objects_preserved_with_defaults():
+    img = np.zeros((20, 20), dtype=np.uint8)
+    img[5:7, 5:10] = 255  # 10 px object
+
+    seg = segment(
+        img,
+        method="manual",
+        invert=False,
+        manual_thresh=100,
+        morph_open_radius=0,
+        morph_close_radius=0,
+    )
+
+    assert seg.sum() == 10


### PR DESCRIPTION
## Summary
- Default small-object and hole removal thresholds are now zero.
- Added UI tooltips exposing these thresholds for interactive tuning.
- Regression test ensures ~10 px objects survive with the new defaults.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f2969a408324ab19dda16069aecb