### PR TITLE
Add option to disable CLAHE preprocessing

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -64,17 +64,19 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     gauss_sigma = float(reg_cfg.get("gauss_blur_sigma", 1.0))
     clahe_clip = float(reg_cfg.get("clahe_clip", 2.0))
     clahe_grid = int(reg_cfg.get("clahe_grid", 8))
+    use_clahe = bool(reg_cfg.get("use_clahe", True))
     initial_radius = int(reg_cfg.get("initial_radius", min(H, W) // 2))
     growth_factor = float(reg_cfg.get("growth_factor", 1.0))
     logger.info(
-        "Preprocessing parameters: gauss_sigma=%.2f clahe_clip=%.2f clahe_grid=%d initial_radius=%d growth_factor=%.2f",
+        "Preprocessing parameters: gauss_sigma=%.2f use_clahe=%s clahe_clip=%.2f clahe_grid=%d initial_radius=%d growth_factor=%.2f",
         gauss_sigma,
+        use_clahe,
         clahe_clip,
         clahe_grid,
         initial_radius,
         growth_factor,
     )
-    imgs_norm = [preprocess(g, gauss_sigma, clahe_clip, clahe_grid) for g in imgs_norm]
+    imgs_norm = [preprocess(g, gauss_sigma, clahe_clip, clahe_grid, use_clahe) for g in imgs_norm]
 
     ensure_dir(out_dir)
     reg_dir = out_dir / "registered"; ensure_dir(reg_dir)

--- a/app/core/registration.py
+++ b/app/core/registration.py
@@ -17,12 +17,12 @@ ECC_MODELS = {
 def has_cuda() -> bool:
     return hasattr(cv2, "cuda") and cv2.cuda.getCudaEnabledDeviceCount() > 0
 
-def preprocess(gray: np.ndarray, gauss_sigma: float, clahe_clip: float, clahe_grid: int) -> np.ndarray:
+def preprocess(gray: np.ndarray, gauss_sigma: float, clahe_clip: float, clahe_grid: int, use_clahe: bool = True) -> np.ndarray:
     g = gray
     if gauss_sigma > 0:
         k = int(max(1, round(gauss_sigma*3))*2 + 1)
         g = cv2.GaussianBlur(g, (k,k), gauss_sigma)
-    if clahe_clip > 0:
+    if use_clahe and clahe_clip > 0:
         clahe = cv2.createCLAHE(clipLimit=clahe_clip, tileGridSize=(clahe_grid,clahe_grid))
         g = clahe.apply(g)
     return g

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -15,6 +15,7 @@ class RegParams:
     max_iters: int = 1000
     eps: float = 1e-6
     gauss_blur_sigma: float = 1.0
+    use_clahe: bool = True
     clahe_clip: float = 2.0
     clahe_grid: int = 8
     initial_radius: int = 20

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,6 +24,7 @@ def test_settings_persist(tmp_path):
     win.gauss_sigma.setValue(2.5)
     win.clahe_clip.setValue(1.5)
     win.clahe_grid.setValue(16)
+    win.use_clahe.setChecked(False)
     win.init_radius.setValue(12)
     win.growth_factor.setValue(1.8)
     win.reg_method.setCurrentText("ORB")
@@ -54,6 +55,7 @@ def test_settings_persist(tmp_path):
     assert win2.gauss_sigma.value() == 2.5
     assert win2.clahe_clip.value() == 1.5
     assert win2.clahe_grid.value() == 16
+    assert not win2.use_clahe.isChecked()
     assert win2.init_radius.value() == 12
     assert win2.growth_factor.value() == 1.8
     assert win2.reg_method.currentText() == "ORB"


### PR DESCRIPTION
## Summary
- add `use_clahe` setting to registration parameters
- expose a "Use CLAHE" checkbox in the GUI and skip CLAHE when disabled
- ensure preprocessing pipeline honors the toggle and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c20699a44c832498192c3d72854b3a