### PR TITLE
Add difference image preview and pipeline option

### DIFF
--- a/app/core/difference.py
+++ b/app/core/difference.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import numpy as np
+import cv2
+
+
+def compute_difference(ref: np.ndarray, mov: np.ndarray) -> np.ndarray:
+    """Compute an enhanced absolute difference image.
+
+    Parameters
+    ----------
+    ref : np.ndarray
+        Reference image (grayscale, uint8).
+    mov : np.ndarray
+        Registered moving image (grayscale, uint8).
+
+    Returns
+    -------
+    np.ndarray
+        8-bit difference image with contrast enhancement.
+    """
+    # Absolute difference
+    diff = cv2.absdiff(ref, mov)
+
+    # Normalize to full 0-255 range
+    diff = cv2.normalize(diff, None, 0, 255, cv2.NORM_MINMAX)
+    diff = diff.astype(np.uint8)
+
+    # Optional CLAHE for local contrast enhancement
+    try:
+        clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+        diff = clahe.apply(diff)
+    except Exception:
+        # If CLAHE creation fails, fall back to normalized difference
+        pass
+
+    return diff


### PR DESCRIPTION
## Summary
- Add `compute_difference` utility for normalized, CLAHE-enhanced absolute differences
- Wire new difference preview UI with optional segmentation using difference images
- Pass `use_difference_for_seg` through pipeline config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c294cc0ed883249e85a9e8a7ed36c5