### PR TITLE
Adjust window layout after collapsing sections

### DIFF
--- a/app/ui/collapsible_section.py
+++ b/app/ui/collapsible_section.py
@@ -41,3 +41,7 @@ class CollapsibleSection(QWidget):
         self._button.setArrowType(
             Qt.ArrowType.DownArrow if visible else Qt.ArrowType.RightArrow
         )
+        self._content.updateGeometry()
+        window = self.window()
+        if window is not None:
+            window.adjustSize()


### PR DESCRIPTION
## Summary
- ensure collapsing sections trigger window size recalculation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2a90e6bd4832492067bc49aae0383