### PR TITLE
Auto-skip outline prefilter in low-contrast or difference segmentation

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -256,11 +256,13 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                 )
         else:
             seg_img = mov_crop
+        use_diff = app_cfg.get("use_difference_for_seg", False) and idx > 0
         bw_mov = segment(
             seg_img,
             method=seg_cfg.get("method", "otsu"),
             invert=bool(seg_cfg.get("invert", True)),
             skip_outline=bool(seg_cfg.get("skip_outline", False)),
+            use_diff=use_diff,
             manual_thresh=int(seg_cfg.get("manual_thresh", 128)),
             adaptive_block=int(seg_cfg.get("adaptive_block", 51)),
             adaptive_C=int(seg_cfg.get("adaptive_C", 5)),

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -360,7 +360,7 @@ class MainWindow(QMainWindow):
         controls.addWidget(self.seg_preview_btn)
         self._add_help(self.rm_obj, "Remove connected components smaller than this area in pixels.")
         self._add_help(self.rm_holes, "Fill holes smaller than this area in pixels.")
-        self._add_help(self.skip_outline, "Bypass outline enhancement for low-contrast images.")
+        self._add_help(self.skip_outline, "Bypass outline enhancement; automatically skipped for difference images or low contrast.")
         self.seg_method.currentTextChanged.connect(self._persist_settings)
         self.invert.toggled.connect(self._persist_settings)
         self.skip_outline.toggled.connect(self._persist_settings)
@@ -964,6 +964,7 @@ class MainWindow(QMainWindow):
                          method=seg.method,
                          invert=seg.invert,
                          skip_outline=seg.skip_outline,
+                         use_diff=self.use_diff_cb.isChecked(),
                          manual_thresh=seg.manual_thresh,
                          adaptive_block=seg.adaptive_block,
                          adaptive_C=seg.adaptive_C,

--- a/tests/test_small_object_preservation.py
+++ b/tests/test_small_object_preservation.py
@@ -31,6 +31,7 @@ def test_skip_outline_preserves_small_bright_objects():
         img,
         method="otsu",
         invert=False,
+        auto_skip_outline=False,
         morph_open_radius=0,
         morph_close_radius=0,
     )
@@ -46,3 +47,28 @@ def test_skip_outline_preserves_small_bright_objects():
 
     assert seg_default.sum() == 0
     assert seg_skip.sum() == 25
+
+
+def test_difference_mode_auto_skips_outline():
+    img = np.zeros((20, 20), dtype=np.uint8)
+    img[5:10, 5:10] = 255  # 25 px square
+
+    seg_diff = segment(
+        img,
+        method="otsu",
+        invert=False,
+        use_diff=True,
+        morph_open_radius=0,
+        morph_close_radius=0,
+    )
+
+    seg_skip = segment(
+        img,
+        method="otsu",
+        invert=False,
+        skip_outline=True,
+        morph_open_radius=0,
+        morph_close_radius=0,
+    )
+
+    assert np.array_equal(seg_diff, seg_skip)


### PR DESCRIPTION
## Summary
- Add `use_diff` and `auto_skip_outline` options in `segment()` to skip black-hat when outlines are weak or when segmenting difference images
- Pass new flag from UI and processing pipeline; update tooltip for skip-outline checkbox
- Test automatic skipping behavior with difference images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2d426d00c832494e2d3b51bcff828