### PR TITLE
Add tests for adaptive and local segmentation thresholds

### DIFF
--- a/tests/test_segmentation_adaptive.py
+++ b/tests/test_segmentation_adaptive.py
@@ -1,0 +1,42 @@
+import numpy as np
+import sys
+from pathlib import Path
+import cv2
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment, outline_focused
+
+
+def test_adaptive_segmentation_matches_cv2_adaptive_threshold():
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+
+    seg = segment(
+        img,
+        method="adaptive",
+        invert=False,
+        adaptive_block=3,
+        adaptive_C=5,
+        morph_open_radius=0,
+        morph_close_radius=0,
+        remove_objects_smaller_px=0,
+        remove_holes_smaller_px=0,
+    )
+
+    feat = outline_focused(img, invert=False)
+    th = cv2.adaptiveThreshold(
+        feat,
+        255,
+        cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+        cv2.THRESH_BINARY,
+        3,
+        5,
+    )
+    expected = (th > 0).astype(np.uint8)
+
+    assert np.array_equal(seg, expected)

--- a/tests/test_segmentation_local.py
+++ b/tests/test_segmentation_local.py
@@ -1,0 +1,34 @@
+import numpy as np
+import sys
+from pathlib import Path
+from skimage import filters
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment, outline_focused
+
+
+def test_local_segmentation_matches_skimage_threshold_local():
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+
+    seg = segment(
+        img,
+        method="local",
+        invert=False,
+        local_block=3,
+        morph_open_radius=0,
+        morph_close_radius=0,
+        remove_objects_smaller_px=0,
+        remove_holes_smaller_px=0,
+    )
+
+    feat = outline_focused(img, invert=False)
+    loc = filters.threshold_local(feat, 3)
+    expected = (feat > loc).astype(np.uint8)
+
+    assert np.array_equal(seg, expected)


### PR DESCRIPTION
## Summary
- add unit test verifying adaptive segmentation matches OpenCV's adaptive threshold
- add unit test verifying local segmentation matches scikit-image threshold_local

## Testing
- `pytest tests/test_segmentation_adaptive.py tests/test_segmentation_local.py tests/test_segmentation_otsu.py -q`
- `pytest` *(fails: `ImportError: libEGL.so.1: cannot open shared object file: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d9afb1a48324aa3b02a59448f005