### PR TITLE
Align diagnostic outputs with previous frame index

### DIFF
--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -54,5 +54,5 @@ def test_difference_output(tmp_path, monkeypatch):
 
     diff_dir = out_dir / "diff"
     assert (diff_dir / "0001_diff.png").exists()
-    assert (diff_dir / "0001_bw_new.png").exists()
-    assert (diff_dir / "0001_bw_lost.png").exists()
+    assert (diff_dir / "0000_bw_new.png").exists()
+    assert (diff_dir / "0000_bw_lost.png").exists()

--- a/tests/test_overlay_frame_alignment.py
+++ b/tests/test_overlay_frame_alignment.py
@@ -1,0 +1,72 @@
+import numpy as np
+import cv2
+from pathlib import Path
+import sys
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.core.processing import analyze_sequence
+from app.core import processing
+
+
+def create_appearance_disappearance_frames(tmp_path):
+    # Frame 0: empty
+    img0 = np.zeros((32, 32), dtype=np.uint8)
+    path0 = tmp_path / "frame0.png"
+    cv2.imwrite(str(path0), img0)
+
+    # Frame 1: object appears
+    img1 = np.zeros_like(img0)
+    cv2.rectangle(img1, (10, 10), (20, 20), 255, -1)
+    path1 = tmp_path / "frame1.png"
+    cv2.imwrite(str(path1), img1)
+
+    # Frame 2: object disappears
+    img2 = np.zeros_like(img0)
+    path2 = tmp_path / "frame2.png"
+    cv2.imwrite(str(path2), img2)
+
+    return [path0, path1, path2]
+
+
+def test_overlay_frame_alignment(tmp_path, monkeypatch):
+    paths = create_appearance_disappearance_frames(tmp_path)
+
+    def fake_register(ref, mov, model="affine", **kwargs):
+        h, w = ref.shape
+        mask = np.ones((h, w), dtype=np.uint8)
+        return True, np.eye(3, dtype=np.float32), mov, mask
+
+    monkeypatch.setattr(processing, "register_ecc", fake_register)
+    # Simple segmentation: foreground where pixel > 0
+    monkeypatch.setattr(processing, "segment", lambda img, **kwargs: (img > 0).astype(np.uint8))
+
+    reg_cfg = {
+        "initial_radius": 0,
+        "gauss_blur_sigma": 0,
+        "clahe_clip": 0,
+        "clahe_grid": 8,
+        "use_masked_ecc": False,
+    }
+    seg_cfg = {}
+    app_cfg = {
+        "direction": "first-to-last",
+        "save_intermediates": True,
+    }
+
+    out_dir = tmp_path / "out"
+    analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
+
+    overlay_dir = out_dir / "overlay"
+    diff_dir = out_dir / "diff"
+
+    # Appearance between frame0 and frame1 should be attributed to frame0
+    assert (overlay_dir / "0000_overlay_mov.png").exists()
+    bw_new = cv2.imread(str(diff_dir / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
+    assert bw_new is not None and np.any(bw_new)
+
+    # Disappearance between frame1 and frame2 should be attributed to frame1
+    assert (overlay_dir / "0001_overlay_mov.png").exists()
+    bw_lost = cv2.imread(str(diff_dir / "0001_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    assert bw_lost is not None and np.any(bw_lost)

--- a/tests/test_overlay_new_lost_colors.py
+++ b/tests/test_overlay_new_lost_colors.py
@@ -51,7 +51,7 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
     out_dir = tmp_path / "out"
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    overlay_img = cv2.imread(str(out_dir / "overlay" / "0001_overlay_mov.png"))
+    overlay_img = cv2.imread(str(out_dir / "overlay" / "0000_overlay_mov.png"))
     assert overlay_img is not None
     green = np.array([0, 255, 0], dtype=np.uint8)
     red = np.array([0, 0, 255], dtype=np.uint8)

--- a/tests/test_synthetic_registration.py
+++ b/tests/test_synthetic_registration.py
@@ -65,10 +65,10 @@ def test_synthetic_registration_alignment(tmp_path):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     reg_dir = out_dir / "registered"
-    prev1 = cv2.imread(str(reg_dir / "0001_prev.png"), cv2.IMREAD_GRAYSCALE)
+    prev0 = cv2.imread(str(reg_dir / "0000_prev.png"), cv2.IMREAD_GRAYSCALE)
     mov1 = cv2.imread(str(reg_dir / "0001_mov.png"), cv2.IMREAD_GRAYSCALE)
-    assert np.array_equal(prev1, mov1)
+    assert np.array_equal(prev0, mov1)
 
-    prev2 = cv2.imread(str(reg_dir / "0002_prev.png"), cv2.IMREAD_GRAYSCALE)
+    prev1 = cv2.imread(str(reg_dir / "0001_prev.png"), cv2.IMREAD_GRAYSCALE)
     mov2 = cv2.imread(str(reg_dir / "0002_mov.png"), cv2.IMREAD_GRAYSCALE)
-    assert np.array_equal(prev2, mov2)
+    assert np.array_equal(prev1, mov2)


### PR DESCRIPTION
## Summary
- track previous frame index in `analyze_sequence`
- save new/lost masks and overlays using the previous frame number
- test appearance/disappearance events to ensure correct overlay attribution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c31103c5c88324978c22849b3b40f1