### PR TITLE
Save full-frame masks and adjust tests

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -238,7 +238,10 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     def _save_mask(idx: int, mask: np.ndarray, x_off: int, y_off: int) -> None:
         if not app_cfg.get("save_masks", False):
             return
-        cv2.imencode('.png', (mask * 255).astype(np.uint8))[1].tofile(
+        h, w = mask.shape[:2]
+        full_mask = np.zeros_like(imgs_gray[idx], dtype=mask.dtype)
+        full_mask[y_off : y_off + h, x_off : x_off + w] = mask
+        cv2.imencode(".png", (full_mask * 255).astype(np.uint8))[1].tofile(
             str(out_dir / f"mask_{idx:04d}.png")
         )
         frame_color = cv2.cvtColor(imgs_gray[idx], cv2.COLOR_GRAY2BGR)

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -91,5 +91,11 @@ def test_save_masks(tmp_path, monkeypatch):
     out_dir = tmp_path / "out"
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    assert (out_dir / "mask_0000.png").exists()
-    assert (out_dir / "mask_0001.png").exists()
+    mask0_path = out_dir / "mask_0000.png"
+    mask1_path = out_dir / "mask_0001.png"
+    assert mask0_path.exists()
+    assert mask1_path.exists()
+    mask0 = cv2.imread(str(mask0_path), cv2.IMREAD_GRAYSCALE)
+    mask1 = cv2.imread(str(mask1_path), cv2.IMREAD_GRAYSCALE)
+    assert mask0.shape == img0.shape
+    assert mask1.shape == img1.shape


### PR DESCRIPTION
## Summary
- Save segmentation masks as full-frame images by padding cropped masks to the original image size.
- Extend pipeline logging test to confirm masks are saved with full image dimensions.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31938ab2c83248bd048c098c48e92