### PR TITLE
Save registered and difference segmentation masks

### DIFF
--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -47,6 +47,7 @@ def test_difference_output(tmp_path, monkeypatch):
         "direction": "first-to-last",
         "use_difference_for_seg": True,
         "save_intermediates": True,
+        "save_masks": True,
     }
 
     out_dir = tmp_path / "out"
@@ -56,3 +57,10 @@ def test_difference_output(tmp_path, monkeypatch):
     assert (diff_dir / "0001_diff.png").exists()
     assert (diff_dir / "0000_bw_new.png").exists()
     assert (diff_dir / "0000_bw_lost.png").exists()
+
+    reg0 = cv2.imread(str(out_dir / "mask_0000_registered.png"), cv2.IMREAD_GRAYSCALE)
+    reg1 = cv2.imread(str(out_dir / "mask_0001_registered.png"), cv2.IMREAD_GRAYSCALE)
+    diff1 = cv2.imread(str(out_dir / "mask_0001_difference.png"), cv2.IMREAD_GRAYSCALE)
+    assert reg0 is not None and reg0.shape == (32, 32)
+    assert reg1 is not None and reg1.shape == (32, 32)
+    assert diff1 is not None and diff1.shape == (32, 32)

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -91,8 +91,8 @@ def test_save_masks(tmp_path, monkeypatch):
     out_dir = tmp_path / "out"
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
-    mask0_path = out_dir / "mask_0000.png"
-    mask1_path = out_dir / "mask_0001.png"
+    mask0_path = out_dir / "mask_0000_registered.png"
+    mask1_path = out_dir / "mask_0001_registered.png"
     assert mask0_path.exists()
     assert mask1_path.exists()
     mask0 = cv2.imread(str(mask0_path), cv2.IMREAD_GRAYSCALE)


### PR DESCRIPTION
## Summary
- compute both registered-image and difference-image segmentation masks when using difference-based segmentation
- save full-frame versions of both mask types to disk and continue using registered masks for ECC
- add tests verifying new masks are created and update existing tests for new filenames

## Testing
- `pytest tests/test_difference_output.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31a7df13c8324a2c92407d7194362