### PR TITLE
Organize difference and binary outputs into subdirectories

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -117,8 +117,18 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
     ensure_dir(out_dir)
     reg_dir = out_dir / "registered"; ensure_dir(reg_dir)
+
     bw_dir = out_dir / "binary"; ensure_dir(bw_dir)
+    bw_mov_dir = bw_dir / "mov"; ensure_dir(bw_mov_dir)
+    bw_prev_dir = bw_dir / "prev"; ensure_dir(bw_prev_dir)
+    bw_overlap_dir = bw_dir / "overlap"; ensure_dir(bw_overlap_dir)
+    bw_empty_dir = bw_dir / "empty"; ensure_dir(bw_empty_dir)
+
     diff_dir = out_dir / "diff"; ensure_dir(diff_dir)
+    diff_diff_dir = diff_dir / "diff"; ensure_dir(diff_diff_dir)
+    diff_new_dir = diff_dir / "new"; ensure_dir(diff_new_dir)
+    diff_lost_dir = diff_dir / "lost"; ensure_dir(diff_lost_dir)
+
     overlay_dir = out_dir / "overlay"; ensure_dir(overlay_dir)
 
     rows: List[Dict] = []
@@ -328,7 +338,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             )
             if app_cfg.get("save_intermediates", True):
                 cv2.imencode(".png", seg_img)[1].tofile(
-                    str(diff_dir / f"{k:04d}_diff.png")
+                    str(diff_diff_dir / f"{k:04d}_diff.png")
                 )
         bw_reg = segment(
             mov_crop,
@@ -355,7 +365,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                 "Frame %d: segmentation mask is empty; skipping ecc_mask update", k
             )
             cv2.imencode(".png", (bw_reg * 255).astype(np.uint8))[1].tofile(
-                str(bw_dir / f"{k:04d}_bw_mov_empty.png")
+                str(bw_empty_dir / f"{k:04d}_bw_mov_empty.png")
             )
         else:
             all_masks_empty = False
@@ -390,24 +400,24 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                 str(reg_dir / f"{k:04d}_mov.png")
             )
             cv2.imencode('.png', (bw_reg * 255).astype(np.uint8))[1].tofile(
-                str(bw_dir / f"{k:04d}_bw_mov.png")
+                str(bw_mov_dir / f"{k:04d}_bw_mov.png")
             )
             if bw_diff is not None:
                 cv2.imencode('.png', (bw_diff * 255).astype(np.uint8))[1].tofile(
                     str(bw_dir / f"{k:04d}_bw_diff.png")
                 )
             cv2.imencode('.png', (prev_bw_crop * 255).astype(np.uint8))[1].tofile(
-                str(bw_dir / f"{prev_k:04d}_bw_prev.png")
+                str(bw_prev_dir / f"{prev_k:04d}_bw_prev.png")
             )
             cv2.imencode('.png', (bw_overlap * 255).astype(np.uint8))[1].tofile(
-                str(bw_dir / f"{prev_k:04d}_bw_overlap.png")
+                str(bw_overlap_dir / f"{prev_k:04d}_bw_overlap.png")
             )
             if idx > 0:
                 cv2.imencode('.png', (bw_new * 255).astype(np.uint8))[1].tofile(
-                    str(diff_dir / f"{prev_k:04d}_bw_new.png")
+                    str(diff_new_dir / f"{prev_k:04d}_bw_new.png")
                 )
                 cv2.imencode('.png', (bw_lost * 255).astype(np.uint8))[1].tofile(
-                    str(diff_dir / f"{prev_k:04d}_bw_lost.png")
+                    str(diff_lost_dir / f"{prev_k:04d}_bw_lost.png")
                 )
                 new_color = tuple(app_cfg.get("overlay_new_color", (0, 255, 0)))
                 lost_color = tuple(app_cfg.get("overlay_lost_color", (0, 0, 255)))

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -54,9 +54,9 @@ def test_difference_output(tmp_path, monkeypatch):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     diff_dir = out_dir / "diff"
-    assert (diff_dir / "0001_diff.png").exists()
-    assert (diff_dir / "0000_bw_new.png").exists()
-    assert (diff_dir / "0000_bw_lost.png").exists()
+    assert (diff_dir / "diff" / "0001_diff.png").exists()
+    assert (diff_dir / "new" / "0000_bw_new.png").exists()
+    assert (diff_dir / "lost" / "0000_bw_lost.png").exists()
 
     reg0 = cv2.imread(str(out_dir / "mask_0000_registered.png"), cv2.IMREAD_GRAYSCALE)
     reg1 = cv2.imread(str(out_dir / "mask_0001_registered.png"), cv2.IMREAD_GRAYSCALE)

--- a/tests/test_empty_mask_warning.py
+++ b/tests/test_empty_mask_warning.py
@@ -66,7 +66,7 @@ def test_warns_and_skips_ecc_mask(tmp_path, caplog):
         df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     assert any("segmentation mask is empty" in rec.message for rec in caplog.records)
-    empty_mask_path = out_dir / "binary" / "0001_bw_mov_empty.png"
+    empty_mask_path = out_dir / "binary" / "empty" / "0001_bw_mov_empty.png"
     assert empty_mask_path.exists()
     row = df[df["frame_index"] == 1].iloc[0]
     assert row["area_mov_px"] == 0

--- a/tests/test_overlay_frame_alignment.py
+++ b/tests/test_overlay_frame_alignment.py
@@ -63,10 +63,10 @@ def test_overlay_frame_alignment(tmp_path, monkeypatch):
 
     # Appearance between frame0 and frame1 should be attributed to frame0
     assert (overlay_dir / "0000_overlay_mov.png").exists()
-    bw_new = cv2.imread(str(diff_dir / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
+    bw_new = cv2.imread(str(diff_dir / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
     assert bw_new is not None and np.any(bw_new)
 
     # Disappearance between frame1 and frame2 should be attributed to frame1
     assert (overlay_dir / "0001_overlay_mov.png").exists()
-    bw_lost = cv2.imread(str(diff_dir / "0001_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    bw_lost = cv2.imread(str(diff_dir / "lost" / "0001_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
     assert bw_lost is not None and np.any(bw_lost)


### PR DESCRIPTION
## Summary
- Create diff, new, lost folders under `diff` output and mov, prev, overlap, empty folders under `binary`
- Save difference frames and masks into their dedicated subdirectories
- Update tests to expect new folder structure

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_difference_output.py tests/test_overlay_frame_alignment.py tests/test_empty_mask_warning.py`

------
https://chatgpt.com/codex/tasks/task_e_68c31bbfa5a48324bcfdcc386cd40139