### PR TITLE
Normalize segmentation previews and stabilize adaptive thresholding

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -78,9 +78,24 @@ def segment(
             _, th = cv2.threshold(feat, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
             bw = (th > 0).astype(np.uint8)
         elif method == "adaptive":
-            blk = max(3, adaptive_block|1)
-            th = cv2.adaptiveThreshold(feat, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, blk, adaptive_C)
-            bw = (th>0).astype(np.uint8)
+            blk = max(3, adaptive_block | 1)
+            if use_diff:
+                rng = int(feat.max() - feat.min())
+                if rng < 2:
+                    bw = np.zeros_like(feat, dtype=np.uint8)
+                    feat = None
+                else:
+                    feat = cv2.normalize(feat, None, 0, 255, cv2.NORM_MINMAX)
+            if feat is not None:
+                th = cv2.adaptiveThreshold(
+                    feat.astype(np.uint8),
+                    255,
+                    cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+                    cv2.THRESH_BINARY,
+                    blk,
+                    adaptive_C,
+                )
+                bw = (th > 0).astype(np.uint8)
         elif method == "local":
             blk = max(3, local_block|1)
             loc = filters.threshold_local(feat, blk)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1001,19 +1001,22 @@ class MainWindow(QMainWindow):
                 gray = self._diff_gray
             else:
                 gray = self._reg_warp
-            bw = segment(gray,
-                         method=seg.method,
-                         invert=seg.invert,
-                         skip_outline=seg.skip_outline,
-                         use_diff=self.use_diff_cb.isChecked(),
-                         manual_thresh=seg.manual_thresh,
-                         adaptive_block=seg.adaptive_block,
-                         adaptive_C=seg.adaptive_C,
-                         local_block=seg.local_block,
-                         morph_open_radius=seg.morph_open_radius,
-                         morph_close_radius=seg.morph_close_radius,
-                         remove_objects_smaller_px=seg.remove_objects_smaller_px,
-                         remove_holes_smaller_px=seg.remove_holes_smaller_px)
+            gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+            bw = segment(
+                gray,
+                method=seg.method,
+                invert=seg.invert,
+                skip_outline=seg.skip_outline,
+                use_diff=self.use_diff_cb.isChecked(),
+                manual_thresh=seg.manual_thresh,
+                adaptive_block=seg.adaptive_block,
+                adaptive_C=seg.adaptive_C,
+                local_block=seg.local_block,
+                morph_open_radius=seg.morph_open_radius,
+                morph_close_radius=seg.morph_close_radius,
+                remove_objects_smaller_px=seg.remove_objects_smaller_px,
+                remove_holes_smaller_px=seg.remove_holes_smaller_px,
+            )
 
             self._seg_gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
             self._seg_overlay = cv2.cvtColor(overlay_outline(gray, bw), cv2.COLOR_BGR2RGB)

--- a/tests/test_segmentation_diff_uniform.py
+++ b/tests/test_segmentation_diff_uniform.py
@@ -1,0 +1,18 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment
+
+
+def test_adaptive_diff_nearly_uniform_not_all_ones():
+    img = np.full((20, 20), 5, dtype=np.uint8)
+    mask = segment(
+        img,
+        method="adaptive",
+        invert=False,
+        use_diff=True,
+    )
+    assert not np.all(mask == 1)


### PR DESCRIPTION
## Summary
- Normalize grayscale preview frames to uint8 before segmentation
- Guard adaptive segmentation from all-one masks on near-uniform diff images
- Add regression test for adaptive diff segmentation

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `pytest tests/test_segmentation_diff_uniform.py -q`
- `python - <<'PY'
import numpy as np
from app.core.segmentation import segment
img = np.full((5,5),5,dtype=np.uint8)
mask = segment(img, method='adaptive', invert=False, use_diff=True)
print(mask)
PY`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt6.QtWidgets import QApplication
from app.ui.main_window import MainWindow
app = QApplication([])
win = MainWindow()
print('window created')
PY` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c31f7a9b608324942b7fb644c0886c