### PR TITLE
Update segmentation method UI and tests

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -44,6 +44,7 @@ class MainWindow(QMainWindow):
         self._diff_gray = None
         self._current_preview = None
         self._build_ui()
+        self._update_seg_controls(self.seg_method.currentText())
         self._param_timer = QTimer(self)
         self._param_timer.setSingleShot(True)
         self._param_timer.setInterval(200)
@@ -107,6 +108,16 @@ class MainWindow(QMainWindow):
             w.setVisible(custom)
         self._refresh_overlay_alpha()
         logger.info("Overlay mode changed: %s", mode)
+
+    def _update_seg_controls(self, method: str) -> None:
+        """Enable/disable threshold widgets based on segmentation method."""
+        manual = method == "manual"
+        adaptive = method == "adaptive"
+        local = method == "local"
+        self.manual_t.setEnabled(manual)
+        self.adaptive_blk.setEnabled(adaptive)
+        self.adaptive_C.setEnabled(adaptive)
+        self.local_blk.setEnabled(local)
 
     def _build_ui(self):
         central = QWidget()
@@ -385,6 +396,7 @@ class MainWindow(QMainWindow):
         self._add_help(self.rm_holes, "Fill holes smaller than this area in pixels.")
         self._add_help(self.skip_outline, "Bypass outline enhancement; automatically skipped for difference images or low contrast.")
         self.seg_method.currentTextChanged.connect(self._persist_settings)
+        self.seg_method.currentTextChanged.connect(self._update_seg_controls)
         self.invert.toggled.connect(self._persist_settings)
         self.skip_outline.toggled.connect(self._persist_settings)
         self.manual_t.valueChanged.connect(self._persist_settings)

--- a/tests/test_segmentation_ui_controls.py
+++ b/tests/test_segmentation_ui_controls.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+import sys
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QSettings
+import pyqtgraph as pg
+
+pg.setConfigOptions(useOpenGL=False)
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.ui.main_window import MainWindow
+
+
+def test_segmentation_method_enables_expected_widgets(tmp_path):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+
+    # Manual method
+    win.seg_method.setCurrentText("manual")
+    assert win.manual_t.isEnabled()
+    assert not win.adaptive_blk.isEnabled()
+    assert not win.adaptive_C.isEnabled()
+    assert not win.local_blk.isEnabled()
+
+    # Adaptive method
+    win.seg_method.setCurrentText("adaptive")
+    assert not win.manual_t.isEnabled()
+    assert win.adaptive_blk.isEnabled()
+    assert win.adaptive_C.isEnabled()
+    assert not win.local_blk.isEnabled()
+
+    # Local method
+    win.seg_method.setCurrentText("local")
+    assert not win.manual_t.isEnabled()
+    assert not win.adaptive_blk.isEnabled()
+    assert not win.adaptive_C.isEnabled()
+    assert win.local_blk.isEnabled()
+
+    # Morphological/removal controls remain enabled
+    for w in (win.open_r, win.close_r, win.rm_obj, win.rm_holes):
+        assert w.isEnabled()
+
+    win.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Add `_update_seg_controls` helper to toggle segmentation threshold widgets and call it on startup
- Connect segmentation method changes to update control enablement
- Test segmentation method UI toggling states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c325db81ac83248e4b2dcde617e17b