### PR TITLE
Skip outline when black-hat lacks dynamic range

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -67,9 +67,9 @@ def segment(
             feat = plain
         else:
             bh = outline_focused(gray, invert=invert)
-            # If the outline-focused image contains almost no signal,
+            # If the outline-focused image lacks dynamic range,
             # it likely washed out features. Fall back to the plain image.
-            if auto_skip_outline and bh.mean() < 1:
+            if auto_skip_outline and (bh.std() < 1 or bh.max() < 2):
                 feat = plain
             else:
                 feat = bh

--- a/tests/test_segmentation_outline_uniform.py
+++ b/tests/test_segmentation_outline_uniform.py
@@ -1,0 +1,39 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app.core.segmentation as segmod
+
+
+def _uniform_bh(gray, invert=True):
+    return np.full_like(gray, 5, dtype=np.uint8)
+
+
+def test_adaptive_skips_near_uniform_outline(monkeypatch):
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+    monkeypatch.setattr(segmod, "outline_focused", _uniform_bh)
+    seg = segmod.segment(img, method="adaptive", invert=False)
+    seg_skip = segmod.segment(img, method="adaptive", invert=False, skip_outline=True)
+    assert np.array_equal(seg, seg_skip)
+    assert not np.all(seg == 1)
+
+
+def test_local_skips_near_uniform_outline(monkeypatch):
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+    monkeypatch.setattr(segmod, "outline_focused", _uniform_bh)
+    seg = segmod.segment(img, method="local", invert=False)
+    seg_skip = segmod.segment(img, method="local", invert=False, skip_outline=True)
+    assert np.array_equal(seg, seg_skip)
+    assert not np.all(seg == 1)


### PR DESCRIPTION
## Summary
- Avoid using black-hat outlines when their dynamic range is too low
- Test adaptive and local segmentation to ensure outline is skipped on near-uniform black-hat output

## Testing
- `pytest tests/test_segmentation_adaptive.py tests/test_segmentation_local.py tests/test_segmentation_outline_uniform.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3298db354832482460bd9cc7ca9db