### PR TITLE
Handle low dynamic range in segmentation

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -79,14 +79,20 @@ def segment(
             bw = (th > 0).astype(np.uint8)
         elif method == "adaptive":
             blk = max(3, adaptive_block | 1)
-            if use_diff:
-                rng = int(feat.max() - feat.min())
-                if rng < 2:
+            rng = int(feat.max() - feat.min())
+            if rng < 2:
+                if use_diff:
                     bw = np.zeros_like(feat, dtype=np.uint8)
                     feat = None
                 else:
-                    feat = cv2.normalize(feat, None, 0, 255, cv2.NORM_MINMAX)
+                    feat = plain
+                    rng = int(feat.max() - feat.min())
+                    if rng < 2:
+                        bw = np.zeros_like(feat, dtype=np.uint8)
+                        feat = None
             if feat is not None:
+                if use_diff:
+                    feat = cv2.normalize(feat, None, 0, 255, cv2.NORM_MINMAX)
                 th = cv2.adaptiveThreshold(
                     feat.astype(np.uint8),
                     255,
@@ -98,8 +104,20 @@ def segment(
                 bw = (th > 0).astype(np.uint8)
         elif method == "local":
             blk = max(3, local_block|1)
-            loc = filters.threshold_local(feat, blk)
-            bw = (feat > loc).astype(np.uint8)
+            rng = int(feat.max() - feat.min())
+            if rng < 2:
+                if use_diff:
+                    bw = np.zeros_like(feat, dtype=np.uint8)
+                    feat = None
+                else:
+                    feat = plain
+                    rng = int(feat.max() - feat.min())
+                    if rng < 2:
+                        bw = np.zeros_like(feat, dtype=np.uint8)
+                        feat = None
+            if feat is not None:
+                loc = filters.threshold_local(feat, blk)
+                bw = (feat > loc).astype(np.uint8)
         else:
             t = int(np.clip(manual_thresh, 0, 255))
             bw = (feat >= t).astype(np.uint8)

--- a/tests/test_segmentation_diff_uniform.py
+++ b/tests/test_segmentation_diff_uniform.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app.core.segmentation import segment
 
 
-def test_adaptive_diff_nearly_uniform_not_all_ones():
+def test_adaptive_diff_nearly_uniform_returns_zero():
     img = np.full((20, 20), 5, dtype=np.uint8)
     mask = segment(
         img,
@@ -15,4 +15,4 @@ def test_adaptive_diff_nearly_uniform_not_all_ones():
         invert=False,
         use_diff=True,
     )
-    assert not np.all(mask == 1)
+    assert np.count_nonzero(mask) == 0

--- a/tests/test_segmentation_low_range.py
+++ b/tests/test_segmentation_low_range.py
@@ -1,0 +1,19 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment
+
+
+def test_adaptive_low_range_returns_zero_mask():
+    img = np.full((10, 10), 42, dtype=np.uint8)
+    mask = segment(img, method="adaptive", invert=False)
+    assert np.count_nonzero(mask) == 0
+
+
+def test_local_low_range_returns_zero_mask():
+    img = np.full((10, 10), 42, dtype=np.uint8)
+    mask = segment(img, method="local", invert=False)
+    assert np.count_nonzero(mask) == 0


### PR DESCRIPTION
## Summary
- Avoid noisy masks by checking image intensity range before adaptive or local thresholding
- Skip thresholding or fall back to the plain image when range is tiny
- Add tests for zero masks on low-range inputs

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_segmentation_low_range.py tests/test_segmentation_diff_uniform.py tests/test_segmentation_local.py tests/test_segmentation_adaptive.py tests/test_segmentation_otsu.py tests/test_segmentation_outline_uniform.py tests/test_segmentation_manual.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c32b65bff083249ad250466e48b029