### PR TITLE
Normalize local diff thresholding and add tests

### DIFF
--- a/app/core/segmentation.py
+++ b/app/core/segmentation.py
@@ -116,6 +116,8 @@ def segment(
                         bw = np.zeros_like(feat, dtype=np.uint8)
                         feat = None
             if feat is not None:
+                if use_diff:
+                    feat = cv2.normalize(feat, None, 0, 255, cv2.NORM_MINMAX)
                 loc = filters.threshold_local(feat, blk)
                 bw = (feat > loc).astype(np.uint8)
         else:

--- a/tests/test_segmentation_diff_uniform.py
+++ b/tests/test_segmentation_diff_uniform.py
@@ -16,3 +16,14 @@ def test_adaptive_diff_nearly_uniform_returns_zero():
         use_diff=True,
     )
     assert np.count_nonzero(mask) == 0
+
+
+def test_local_diff_nearly_uniform_returns_zero():
+    img = np.full((20, 20), 5, dtype=np.uint8)
+    mask = segment(
+        img,
+        method="local",
+        invert=False,
+        use_diff=True,
+    )
+    assert np.count_nonzero(mask) == 0

--- a/tests/test_segmentation_local.py
+++ b/tests/test_segmentation_local.py
@@ -2,6 +2,7 @@ import numpy as np
 import sys
 from pathlib import Path
 from skimage import filters
+import cv2
 
 # Ensure the application package is on the import path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -28,6 +29,33 @@ def test_local_segmentation_matches_skimage_threshold_local():
     )
 
     feat = outline_focused(img, invert=False)
+    loc = filters.threshold_local(feat, 3)
+    expected = (feat > loc).astype(np.uint8)
+
+    assert np.array_equal(seg, expected)
+
+
+def test_local_segmentation_use_diff_matches_skimage_threshold_local():
+    img = np.array(
+        [[10, 60, 200],
+         [100, 150, 250],
+         [30, 180, 220]],
+        dtype=np.uint8,
+    )
+
+    seg = segment(
+        img,
+        method="local",
+        invert=False,
+        use_diff=True,
+        local_block=3,
+        morph_open_radius=0,
+        morph_close_radius=0,
+        remove_objects_smaller_px=0,
+        remove_holes_smaller_px=0,
+    )
+
+    feat = cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX)
     loc = filters.threshold_local(feat, 3)
     expected = (feat > loc).astype(np.uint8)
 


### PR DESCRIPTION
## Summary
- Normalize diff images before local thresholding, mirroring adaptive branch behavior
- Add tests for local segmentation with `use_diff` enabled and for uniform diff frames

## Testing
- `pytest` *(fails: RuntimeError: wrapped C/C++ object of type QComboBox has been deleted)*
- `pytest tests/test_segmentation_local.py tests/test_segmentation_diff_uniform.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32c45efa08324877446d29a10de5a