### PR TITLE
Fix segmentation preview normalization

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1061,7 +1061,12 @@ class MainWindow(QMainWindow):
                 gray = self._diff_gray
             else:
                 gray = self._reg_warp
-            gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+            # Mirror pipeline input handling: pass the raw frame to ``segment`` and
+            # only normalize when necessary. ``compute_difference`` and
+            # ``imread_gray`` already yield ``uint8`` images, so avoid double
+            # scaling unless a non-uint8 array arrives here.
+            if gray.dtype != np.uint8:
+                gray = cv2.normalize(gray, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
             bw = segment(
                 gray,
                 method=seg.method,


### PR DESCRIPTION
## Summary
- Avoid redundant normalization in `_preview_segmentation`, only scaling frames when they aren't `uint8`
- Mirror pipeline input handling so preview segmentation receives raw frames and respects `use_diff`

## Testing
- `pytest -q` *(fails: tests/test_segmentation_outline_uniform.py::test_adaptive_skips_near_uniform_outline, tests/test_segmentation_outline_uniform.py::test_local_skips_near_uniform_outline)*

------
https://chatgpt.com/codex/tasks/task_e_68c330ad363c8324b30b472e4890ec3a