### PR TITLE
Export diff masks regardless of segmentation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Otherwise it runs on CPU with multi-processing. To install a CUDA wheel, conside
 
 ### Intermediate outputs
 When `save_intermediates` is enabled, the pipeline saves additional artifacts alongside the final results.
-Difference images are written to the `diff/` subfolder with names like `{frame}_diff.png`.
-These files are the same difference maps shown in the UI when using the **Preview Difference** button.
+For every pair of frames a raw difference (`{frame}_diff.png`) and its thresholded mask
+(`{frame}_bw_diff.png`) are written to `diff/diff/`. The binary mask is also duplicated in the
+`binary/` directory. These files are the same difference maps shown in the UI when using the
+**Preview Difference** button.
 
 ### Project layout
 - `app/main.py` — app entry, sets up MainWindow.

--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -315,9 +315,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             warped = cv2.warpPerspective(imgs_norm[k], T, (W, H))
             registered_frames[k] = warped
         mov_crop = warped[y_k:y_k + h_k, x_k:x_k + w_k]
-        use_diff = app_cfg.get("use_difference_for_seg", False) and idx > 0
+        seg_img = None
         bw_diff = None
-        if use_diff:
+        if idx > 0:
             seg_img = compute_difference(
                 prev_crop, mov_crop, method=app_cfg.get("difference_method", "abs")
             )
@@ -339,6 +339,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             if app_cfg.get("save_intermediates", True):
                 cv2.imencode(".png", seg_img)[1].tofile(
                     str(diff_diff_dir / f"{k:04d}_diff.png")
+                )
+                cv2.imencode(".png", (bw_diff * 255).astype(np.uint8))[1].tofile(
+                    str(diff_diff_dir / f"{k:04d}_bw_diff.png")
                 )
         bw_reg = segment(
             mov_crop,

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -58,7 +58,7 @@ class AppParams:
     save_png: bool = False
     save_intermediates: bool = True
     save_masks: bool = False
-    use_difference_for_seg: bool = False
+    use_difference_for_seg: bool = False  # diff masks saved regardless
     difference_method: str = "abs"
     use_file_timestamps: bool = True
     normalize: bool = True


### PR DESCRIPTION
## Summary
- always compute frame-to-frame difference and threshold it to a binary mask
- export diff masks to `diff/diff/` and `binary/` for every processed pair
- document diff-frame export and note config behaviour
- test diff export with and without difference-based segmentation

## Testing
- `QT_QPA_PLATFORM=offscreen pytest` *(fails: wrapped C/C++ object of type QComboBox has been deleted)*
- `QT_QPA_PLATFORM=offscreen pytest tests/test_difference_output.py`


------
https://chatgpt.com/codex/tasks/task_e_68c33341d71c832483e5db13bf91267a