### PR TITLE
Organize diff outputs into raw and bw directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Otherwise it runs on CPU with multi-processing. To install a CUDA wheel, conside
 
 ### Intermediate outputs
 When `save_intermediates` is enabled, the pipeline saves additional artifacts alongside the final results.
-For every pair of frames a raw difference (`{frame}_diff.png`) and its thresholded mask
-(`{frame}_bw_diff.png`) are written to `diff/diff/`. The binary mask is also duplicated in the
+For every pair of frames a raw difference (`{frame}_diff.png`) is written to `diff/raw/` and its
+thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. The binary mask is also duplicated in the
 `binary/` directory. These files are the same difference maps shown in the UI when using the
 **Preview Difference** button.
 

--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -125,7 +125,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     bw_empty_dir = bw_dir / "empty"; ensure_dir(bw_empty_dir)
 
     diff_dir = out_dir / "diff"; ensure_dir(diff_dir)
-    diff_diff_dir = diff_dir / "diff"; ensure_dir(diff_diff_dir)
+    diff_raw_dir = diff_dir / "raw"; ensure_dir(diff_raw_dir)
+    diff_bw_dir = diff_dir / "bw"; ensure_dir(diff_bw_dir)
     diff_new_dir = diff_dir / "new"; ensure_dir(diff_new_dir)
     diff_lost_dir = diff_dir / "lost"; ensure_dir(diff_lost_dir)
 
@@ -354,10 +355,10 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             )
             if app_cfg.get("save_intermediates", True):
                 cv2.imencode(".png", seg_img)[1].tofile(
-                    str(diff_diff_dir / f"{k:04d}_diff.png")
+                    str(diff_raw_dir / f"{k:04d}_diff.png")
                 )
                 cv2.imencode(".png", (bw_diff * 255).astype(np.uint8))[1].tofile(
-                    str(diff_diff_dir / f"{k:04d}_bw_diff.png")
+                    str(diff_bw_dir / f"{k:04d}_bw_diff.png")
                 )
         bw_reg = segment(
             mov_crop,
@@ -408,12 +409,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
         bw_overlap = (prev_bw_crop & seg_mask).astype(np.uint8)
         bw_union = (prev_bw_crop | seg_mask).astype(np.uint8)
-        if direction == "last-to-first":
-            bw_new = (prev_bw_crop & (~seg_mask)).astype(np.uint8)
-            bw_lost = (seg_mask & (~prev_bw_crop)).astype(np.uint8)
-        else:
-            bw_new = (seg_mask & (~prev_bw_crop)).astype(np.uint8)
-            bw_lost = (prev_bw_crop & (~seg_mask)).astype(np.uint8)
+        bw_new = (seg_mask & (~prev_bw_crop)).astype(np.uint8)
+        bw_lost = (prev_bw_crop & (~seg_mask)).astype(np.uint8)
         area_new_px = int(bw_new.sum())
         area_lost_px = int(bw_lost.sum())
 

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -55,8 +55,8 @@ def test_difference_output(tmp_path, monkeypatch):
 
     diff_dir = out_dir / "diff"
     bw_dir = out_dir / "binary"
-    assert (diff_dir / "diff" / "0001_diff.png").exists()
-    assert (diff_dir / "diff" / "0001_bw_diff.png").exists()
+    assert (diff_dir / "raw" / "0001_diff.png").exists()
+    assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
     assert (bw_dir / "0001_bw_diff.png").exists()
     assert (diff_dir / "new" / "0000_bw_new.png").exists()
     assert (diff_dir / "lost" / "0000_bw_lost.png").exists()
@@ -100,6 +100,6 @@ def test_difference_output_disabled(tmp_path, monkeypatch):
 
     diff_dir = out_dir / "diff"
     bw_dir = out_dir / "binary"
-    assert (diff_dir / "diff" / "0001_diff.png").exists()
-    assert (diff_dir / "diff" / "0001_bw_diff.png").exists()
+    assert (diff_dir / "raw" / "0001_diff.png").exists()
+    assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
     assert (bw_dir / "0001_bw_diff.png").exists()


### PR DESCRIPTION
## Summary
- Save raw difference images to `diff/raw` and binary masks to `diff/bw`
- Adjust tests and docs for new diff folder layout
- Simplify new/lost mask calculation to be direction-independent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c40b63b7048324b496e65fb72bd2d0