### PR TITLE
Add Multi-Otsu segmentation method and test

### DIFF
--- a/tests/test_segmentation_multi_otsu.py
+++ b/tests/test_segmentation_multi_otsu.py
@@ -1,0 +1,29 @@
+import numpy as np
+import sys
+from pathlib import Path
+from skimage import filters
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core.segmentation import segment
+
+
+def test_multi_otsu_segmentation_two_classes():
+    img = np.zeros((5, 5), dtype=np.uint8)
+    img[:, 2:] = 200
+
+    seg = segment(
+        img,
+        method="multi_otsu",
+        invert=False,
+        skip_outline=True,
+        morph_open_radius=0,
+        morph_close_radius=0,
+        remove_objects_smaller_px=0,
+        remove_holes_smaller_px=0,
+    )
+
+    t = filters.threshold_multiotsu(img, classes=2)
+    expected = (img >= t[0]).astype(np.uint8)
+
+    assert np.array_equal(seg, expected)


### PR DESCRIPTION
## Summary
- document `multi_otsu` as a segmentation method and show multi-level usage
- implement `multi_otsu` thresholding branch in `segment`
- add regression test for multi-level Otsu segmentation

## Testing
- `pytest tests/test_segmentation_multi_otsu.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c41d4ca0148324bda7c6490ce2ea52