### PR TITLE
Expose additional segmentation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- Support for `yen` and `multi_otsu` thresholding methods in `segment`.
+- Support for additional thresholding methods (`multi_otsu`, `li`, `yen`) in `segment` and the UI combo box.
   - `tests/test_segmentation_yen.py` covers Yen thresholding on low-contrast images.
   - `tests/test_segmentation_multi_otsu.py` checks Multi-Otsu segmentation with two classes.
+  - `tests/test_segmentation_li.py` verifies Li thresholding.
 - Usage notes: Yen excels on low-contrast backgrounds, while Multi-Otsu is suited for images with distinct histogram peaks.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. The binary mask is also 
 - `app/models/config.py` — dataclasses for parameters; JSON presets; QSettings persistence.
 - `app/core/io_utils.py` — file discovery, timestamp spacing, safe I/O.
 - `app/core/registration.py` — ECC / ORB(+RANSAC) on CPU; CUDA path when available. ECC assumes sufficient texture; nearly uniform frames can cause the optimizer to diverge, yielding NaN transforms that are handled by falling back to the identity matrix.
-- `app/core/segmentation.py` — outline-focused segmentation (black-hat + Otsu/adaptive), morphology; `skip_outline` option bypasses the prefilter for low-contrast images.
+- `app/core/segmentation.py` — outline-focused segmentation (black-hat + Otsu, Multi-Otsu, Li, Yen, adaptive, local, or manual thresholding), morphology; `skip_outline` option bypasses the prefilter for low-contrast images.
 - `app/core/background.py` — on-the-fly background estimation (temporal median of early frames, fallback to blur).
 - `app/core/processing.py` — end-to-end per-frame pipeline; overlap cropping; metrics aggregation.
 - `app/core/multiproc.py` — ProcessPool execution with chunking; CPU core detection.

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -6,7 +6,15 @@ from PyQt6.QtCore import QSettings
 
 RegistrationModel = Literal["translation","euclidean","affine","homography"]
 RegMethod = Literal["ECC", "ORB", "ORB+ECC"]
-SegMethod = Literal["otsu","adaptive","local","manual"]
+SegMethod = Literal[
+    "otsu",
+    "multi_otsu",
+    "li",
+    "yen",
+    "adaptive",
+    "local",
+    "manual",
+]
 
 @dataclass
 class RegParams:

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -363,7 +363,17 @@ class MainWindow(QMainWindow):
         # Segmentation params
         seg_section = CollapsibleSection("Segmentation")
         seg_grid = QGridLayout()
-        self.seg_method = QComboBox(); self.seg_method.addItems(["otsu","adaptive","local","manual"]); self.seg_method.setCurrentText(self.seg.method)
+        self.seg_method = QComboBox()
+        self.seg_method.addItems([
+            "otsu",
+            "multi_otsu",
+            "li",
+            "yen",
+            "adaptive",
+            "local",
+            "manual",
+        ])
+        self.seg_method.setCurrentText(self.seg.method)
         self.invert = QCheckBox("Cells darker (invert)"); self.invert.setChecked(self.seg.invert)
         self.skip_outline = QCheckBox("Skip outline prefilter"); self.skip_outline.setChecked(self.seg.skip_outline)
         self.manual_t = QSpinBox(); self.manual_t.setRange(0,255); self.manual_t.setValue(self.seg.manual_thresh)

--- a/tests/test_run_pipeline_seg_cfg.py
+++ b/tests/test_run_pipeline_seg_cfg.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 import numpy as np
 import cv2
+import pytest
 from PyQt6.QtWidgets import QApplication
 
 
-def test_run_pipeline_passes_segmentation_params(tmp_path, monkeypatch):
+@pytest.mark.parametrize("method", ["otsu", "multi_otsu", "li", "yen"])
+def test_run_pipeline_passes_segmentation_params(tmp_path, monkeypatch, method):
     """Ensure seg_cfg includes all preview params and is passed unchanged."""
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -18,6 +20,7 @@ def test_run_pipeline_passes_segmentation_params(tmp_path, monkeypatch):
     from app.ui.main_window import MainWindow
 
     win = MainWindow()
+    win.seg_method.setCurrentText(method)
 
     # Create a dummy image path so _run_pipeline has something to process
     img = np.zeros((10, 10), dtype=np.uint8)

--- a/tests/test_segmentation_ui_controls.py
+++ b/tests/test_segmentation_ui_controls.py
@@ -42,6 +42,14 @@ def test_segmentation_method_enables_expected_widgets(tmp_path):
     assert not win.adaptive_C.isEnabled()
     assert win.local_blk.isEnabled()
 
+    # Global threshold methods
+    for method in ("otsu", "multi_otsu", "li", "yen"):
+        win.seg_method.setCurrentText(method)
+        assert not win.manual_t.isEnabled()
+        assert not win.adaptive_blk.isEnabled()
+        assert not win.adaptive_C.isEnabled()
+        assert not win.local_blk.isEnabled()
+
     # Morphological/removal controls remain enabled
     for w in (win.open_r, win.close_r, win.rm_obj, win.rm_holes):
         assert w.isEnabled()


### PR DESCRIPTION
## Summary
- extend `SegMethod` and UI combo box with `multi_otsu`, `li` and `yen`
- validate control state for each method and ensure pipeline passes new config values
- document availability of new segmentation options

## Testing
- `pytest tests/test_segmentation_ui_controls.py tests/test_run_pipeline_seg_cfg.py`


------
https://chatgpt.com/codex/tasks/task_e_68c42eee810c832486bef130bd099318