### PR TITLE
Record segmentation and difference metadata in per-frame summary

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -416,6 +416,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         bw_lost = (prev_bw_crop & (~seg_mask)).astype(np.uint8)
         area_new_px = int(bw_new.sum())
         area_lost_px = int(bw_lost.sum())
+        area_overlap_px = int(bw_overlap.sum())
 
         row = {
             "frame_index": k,
@@ -429,6 +430,9 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             "area_union_px": int(bw_union.sum()),
             "area_new_px": area_new_px,
             "area_lost_px": area_lost_px,
+            "area_overlap_px": area_overlap_px,
+            "segmentation_method": seg_cfg.get("method"),
+            "difference_method": app_cfg.get("difference_method", "abs"),
             "to_ref_transform": T.flatten().tolist(),
         }
         rows.append(row)

--- a/tests/test_growth_factor.py
+++ b/tests/test_growth_factor.py
@@ -57,3 +57,6 @@ def test_final_mask_consistent_across_frames(tmp_path):
     df = run(paths)
     assert df["overlap_w"].nunique() == 1
     assert df["overlap_h"].nunique() == 1
+    assert (df["segmentation_method"] == "manual").all()
+    assert (df["difference_method"] == "abs").all()
+    assert (df["area_overlap_px"] == df["overlap_px"]).all()

--- a/tests/test_per_frame_crop_rects.py
+++ b/tests/test_per_frame_crop_rects.py
@@ -73,4 +73,8 @@ def test_per_frame_crop_rectangles(tmp_path):
     assert int(row1["overlap_h"]) == 50
     assert int(row2["overlap_w"]) == 30
     assert int(row2["overlap_h"]) == 50
+    assert row1["segmentation_method"] == seg_cfg["method"]
+    assert row2["difference_method"] == app_cfg.get("difference_method", "abs")
+    assert int(row1["area_overlap_px"]) == int(row1["overlap_px"])
+    assert int(row2["area_overlap_px"]) == int(row2["overlap_px"])
 


### PR DESCRIPTION
## Summary
- Track segmentation method, difference method, and overlap area for each frame in `analyze_sequence`
- Verify new metadata fields in per-frame crop and growth factor tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c439395a188324a13fa6b265984699