### PR TITLE
Add diff mask evaluation utility and tests

### DIFF
--- a/app/core/evaluation.py
+++ b/app/core/evaluation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Dict, Any
+
+import cv2
+import numpy as np
+import pandas as pd
+
+
+def _index_from_name(path: Path) -> int:
+    """Extract the leading frame index from ``path``."""
+    m = re.match(r"(\d+)", path.stem)
+    if not m:
+        raise ValueError(f"Unexpected filename {path.name}")
+    return int(m.group(1))
+
+
+def _read_mask(path: Path | None) -> np.ndarray | None:
+    """Read a mask image if ``path`` exists.
+
+    Parameters
+    ----------
+    path : Path | None
+        Image path. When ``None`` or missing, ``None`` is returned.
+    """
+    if path is None or not path.exists():
+        return None
+    mask = cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
+    if mask is None:
+        raise ValueError(f"Failed to read {path}")
+    return mask
+
+
+def evaluate_diff_masks(
+    diff_dir: Path,
+    *,
+    csv_path: Path | str | None = None,
+) -> pd.DataFrame:
+    """Evaluate binary difference masks.
+
+    This function scans ``diff_dir`` for ``bw``, ``new`` and ``lost`` subfolders
+    produced by :func:`app.core.processing.analyze_sequence`. For each frame
+    interval it loads the corresponding masks and computes simple area metrics.
+
+    Parameters
+    ----------
+    diff_dir : Path
+        Directory containing ``bw``, ``new`` and ``lost`` subdirectories.
+    csv_path : Path | str | None, optional
+        When provided, the resulting :class:`pandas.DataFrame` is written to this
+        CSV file. Relative paths are resolved inside ``diff_dir``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table with columns ``frame_index``, ``area_diff_px``, ``area_new_px``,
+        ``area_lost_px`` and ``net_new_px``.
+    """
+    diff_dir = Path(diff_dir)
+    bw_dir = diff_dir / "bw"
+    new_dir = diff_dir / "new"
+    lost_dir = diff_dir / "lost"
+
+    bw_map: Dict[int, Path] = {}
+    new_map: Dict[int, Path] = {}
+    lost_map: Dict[int, Path] = {}
+
+    if bw_dir.exists():
+        for p in bw_dir.glob("*.png"):
+            bw_map[_index_from_name(p)] = p
+    if new_dir.exists():
+        for p in new_dir.glob("*.png"):
+            new_map[_index_from_name(p)] = p
+    if lost_dir.exists():
+        for p in lost_dir.glob("*.png"):
+            lost_map[_index_from_name(p)] = p
+
+    frame_indices = sorted(set(new_map) | set(lost_map))
+    rows: list[Dict[str, Any]] = []
+    for idx in frame_indices:
+        new_mask = _read_mask(new_map.get(idx))
+        lost_mask = _read_mask(lost_map.get(idx))
+        # ``bw`` masks are indexed by the moving frame (idx+1)
+        diff_mask = _read_mask(bw_map.get(idx + 1))
+        if diff_mask is None:
+            diff_mask = _read_mask(bw_map.get(idx))
+
+        area_new = int(np.count_nonzero(new_mask)) if new_mask is not None else 0
+        area_lost = int(np.count_nonzero(lost_mask)) if lost_mask is not None else 0
+        area_diff = int(np.count_nonzero(diff_mask)) if diff_mask is not None else 0
+
+        rows.append(
+            {
+                "frame_index": idx,
+                "area_diff_px": area_diff,
+                "area_new_px": area_new,
+                "area_lost_px": area_lost,
+                "net_new_px": area_new - area_lost,
+            }
+        )
+
+    df = pd.DataFrame(rows).sort_values("frame_index").reset_index(drop=True)
+
+    if csv_path is not None:
+        csv_path = Path(csv_path)
+        if not csv_path.is_absolute():
+            csv_path = diff_dir / csv_path
+        df.to_csv(csv_path, index=False)
+
+    return df

--- a/tests/test_evaluate_diff_masks.py
+++ b/tests/test_evaluate_diff_masks.py
@@ -1,0 +1,45 @@
+import numpy as np
+import cv2
+from pathlib import Path
+import sys
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.core.evaluation import evaluate_diff_masks
+
+
+def create_masks(tmp_path: Path) -> Path:
+    diff_dir = tmp_path / "diff"
+    (diff_dir / "bw").mkdir(parents=True)
+    (diff_dir / "new").mkdir(parents=True)
+    (diff_dir / "lost").mkdir(parents=True)
+
+    new_mask = np.zeros((4, 4), dtype=np.uint8)
+    new_mask[0, 0] = 255
+    new_mask[1, 1] = 255
+
+    lost_mask = np.zeros((4, 4), dtype=np.uint8)
+    lost_mask[0, 1] = 255
+
+    diff_mask = np.zeros((4, 4), dtype=np.uint8)
+    diff_mask[0, 0] = 255
+    diff_mask[1, 1] = 255
+    diff_mask[0, 1] = 255
+
+    cv2.imwrite(str(diff_dir / "new" / "0000_bw_new.png"), new_mask)
+    cv2.imwrite(str(diff_dir / "lost" / "0000_bw_lost.png"), lost_mask)
+    cv2.imwrite(str(diff_dir / "bw" / "0001_bw_diff.png"), diff_mask)
+    return diff_dir
+
+
+def test_evaluate_diff_masks(tmp_path):
+    diff_dir = create_masks(tmp_path)
+    df = evaluate_diff_masks(diff_dir, csv_path="summary.csv")
+    assert df.shape[0] == 1
+    row = df.iloc[0]
+    assert row["area_new_px"] == 2
+    assert row["area_lost_px"] == 1
+    assert row["net_new_px"] == 1
+    assert row["area_diff_px"] == 3
+    assert (diff_dir / "summary.csv").exists()


### PR DESCRIPTION
## Summary
- add `evaluate_diff_masks` to compute new/lost pixel areas across diff masks and optional CSV export
- cover evaluation utility with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c448be4a2483249aa0e075190f92a6