### PR TITLE
Add green-magenta detection test coverage

### DIFF
--- a/tests/test_new_lost_direction.py
+++ b/tests/test_new_lost_direction.py
@@ -23,6 +23,23 @@ def create_frames(tmp_path):
     return [path0, path1], img0
 
 
+def create_intensity_frames(tmp_path, v0=150, v1=200):
+    obj = np.zeros((32, 32), dtype=np.uint8)
+    cv2.rectangle(obj, (5, 5), (15, 15), 255, -1)
+
+    img0 = np.zeros_like(obj)
+    img1 = np.zeros_like(obj)
+    img0[obj > 0] = v0
+    img1[obj > 0] = v1
+
+    path0 = tmp_path / "frame0.png"
+    path1 = tmp_path / "frame1.png"
+    cv2.imwrite(str(path0), img0)
+    cv2.imwrite(str(path1), img1)
+
+    return [path0, path1], obj
+
+
 def setup(monkeypatch):
     def fake_register(ref, mov, model="affine", **kwargs):
         h, w = ref.shape
@@ -51,12 +68,23 @@ def boundary_from(mask):
 
 
 def run_direction(paths, reg_cfg, seg_cfg, direction, tmp_path):
-    app_cfg = {"direction": direction, "save_intermediates": True}
+    app_cfg = {
+        "direction": direction,
+        "save_intermediates": True,
+        "overlay_new_color": (0, 255, 0),
+        "overlay_lost_color": (255, 0, 255),
+    }
     out_dir = tmp_path / f"out_{direction}"
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
     prev_idx = 0 if direction == "first-to-last" else 1
-    new_mask = cv2.imread(str(out_dir / "diff" / "new" / f"{prev_idx:04d}_bw_new.png"), cv2.IMREAD_GRAYSCALE)
-    lost_mask = cv2.imread(str(out_dir / "diff" / "lost" / f"{prev_idx:04d}_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    new_mask = cv2.imread(
+        str(out_dir / "diff" / "new" / f"{prev_idx:04d}_bw_new.png"),
+        cv2.IMREAD_GRAYSCALE,
+    )
+    lost_mask = cv2.imread(
+        str(out_dir / "diff" / "lost" / f"{prev_idx:04d}_bw_lost.png"),
+        cv2.IMREAD_GRAYSCALE,
+    )
     overlay = cv2.imread(str(out_dir / "overlay" / f"{prev_idx:04d}_overlay_mov.png"))
     return new_mask, lost_mask, overlay
 
@@ -70,14 +98,41 @@ def test_new_lost_direction(tmp_path, monkeypatch):
     new_mask, lost_mask, overlay = run_direction(paths, reg_cfg, seg_cfg, "first-to-last", tmp_path)
     assert np.array_equal(new_mask, np.zeros_like(obj))
     assert np.array_equal(lost_mask, obj)
-    red_mask = (overlay == np.array([0, 0, 255], dtype=np.uint8)).all(axis=2).astype(np.uint8) * 255
-    assert np.array_equal(red_mask, obj_boundary)
-    assert not (overlay == np.array([0, 255, 0], dtype=np.uint8)).all(axis=2).any()
+    magenta_mask = (
+        overlay == np.array([255, 0, 255], dtype=np.uint8)
+    ).all(axis=2).astype(np.uint8) * 255
+    assert np.array_equal(magenta_mask, obj_boundary)
+    assert not (
+        overlay == np.array([0, 255, 0], dtype=np.uint8)
+    ).all(axis=2).any()
 
     # last-to-first: object is new
     new_mask, lost_mask, overlay = run_direction(paths, reg_cfg, seg_cfg, "last-to-first", tmp_path)
     assert np.array_equal(new_mask, obj)
     assert np.array_equal(lost_mask, np.zeros_like(obj))
-    green_mask = (overlay == np.array([0, 255, 0], dtype=np.uint8)).all(axis=2).astype(np.uint8) * 255
+    green_mask = (
+        overlay == np.array([0, 255, 0], dtype=np.uint8)
+    ).all(axis=2).astype(np.uint8) * 255
     assert np.array_equal(green_mask, obj_boundary)
-    assert not (overlay == np.array([0, 0, 255], dtype=np.uint8)).all(axis=2).any()
+    assert not (
+        overlay == np.array([255, 0, 255], dtype=np.uint8)
+    ).all(axis=2).any()
+
+
+def test_intensity_gain_loss(tmp_path, monkeypatch):
+    paths, obj = create_intensity_frames(tmp_path)
+    reg_cfg, seg_cfg = setup(monkeypatch)
+
+    # first-to-last: intensity increases -> new region
+    new_mask, lost_mask, _ = run_direction(
+        paths, reg_cfg, seg_cfg, "first-to-last", tmp_path
+    )
+    assert np.array_equal(new_mask, obj)
+    assert np.array_equal(lost_mask, np.zeros_like(obj))
+
+    # last-to-first: intensity decreases -> lost region
+    new_mask, lost_mask, _ = run_direction(
+        paths, reg_cfg, seg_cfg, "last-to-first", tmp_path
+    )
+    assert np.array_equal(new_mask, np.zeros_like(obj))
+    assert np.array_equal(lost_mask, obj)

--- a/tests/test_overlay_new_lost_colors.py
+++ b/tests/test_overlay_new_lost_colors.py
@@ -45,7 +45,7 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
         "direction": "first-to-last",
         "save_intermediates": True,
         "overlay_new_color": (0, 255, 0),
-        "overlay_lost_color": (0, 0, 255),
+        "overlay_lost_color": (255, 0, 255),
     }
 
     out_dir = tmp_path / "out"
@@ -54,6 +54,19 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
     overlay_img = cv2.imread(str(out_dir / "overlay" / "0000_overlay_mov.png"))
     assert overlay_img is not None
     green = np.array([0, 255, 0], dtype=np.uint8)
-    red = np.array([0, 0, 255], dtype=np.uint8)
+    magenta = np.array([255, 0, 255], dtype=np.uint8)
     assert (overlay_img == green).all(axis=2).any()
-    assert (overlay_img == red).all(axis=2).any()
+    assert (overlay_img == magenta).all(axis=2).any()
+
+    bw_new = cv2.imread(str(out_dir / "diff" / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
+    bw_lost = cv2.imread(str(out_dir / "diff" / "lost" / "0000_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+
+    mask0 = cv2.imread(str(paths[0]), cv2.IMREAD_GRAYSCALE)
+    mask1 = cv2.imread(str(paths[1]), cv2.IMREAD_GRAYSCALE)
+    mask0 = (mask0 > 127).astype(np.uint8) * 255
+    mask1 = (mask1 > 127).astype(np.uint8) * 255
+    expected_new = ((mask1 == 255) & (mask0 == 0)).astype(np.uint8) * 255
+    expected_lost = ((mask0 == 255) & (mask1 == 0)).astype(np.uint8) * 255
+
+    assert np.array_equal(bw_new, expected_new)
+    assert np.array_equal(bw_lost, expected_lost)


### PR DESCRIPTION
## Summary
- Update new/lost direction tests for green–magenta composite detection
- Verify diff masks and overlays using magenta for lost regions
- Add intensity change scenarios ensuring gain/loss classification in both directions

## Testing
- `pytest tests/test_new_lost_direction.py tests/test_overlay_new_lost_colors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c480b593188324a2d1aaf855711b7f