### PR TITLE
feat: adaptive color thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. The binary mask is also 
 - `diff/new/` — binary masks highlighting regions that newly appear, used for evaluation.
 - `diff/lost/` — binary masks highlighting regions that disappear, used for evaluation.
 
-The separation between the magenta and green channels is determined by an
-adaptive Otsu threshold on the channel difference.  To reduce noise or grow
-contiguous regions in these masks, set `gm_morph_kernel` in the application
-config to a kernel size (>0) for morphological closing.
+The separation between the magenta and green channels is determined in LAB
+color space using an adaptive threshold on the "a" channel.  By default an
+Otsu threshold (`gm_thresh_method="otsu"`) is used, but a percentile
+(`gm_thresh_percentile`, default `99.0`) can be selected instead.  To remove
+speckles and recover full structures the masks are optionally processed with
+morphological closing (`gm_close_kernel`, default `3`) and dilation
+(`gm_dilate_kernel`, default `0`).
 
 ### Project layout
 - `app/main.py` — app entry, sets up MainWindow.

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -69,7 +69,10 @@ class AppParams:
     save_masks: bool = False
     use_difference_for_seg: bool = False  # diff masks saved regardless
     difference_method: str = "abs"
-    gm_morph_kernel: int = 0  # closing kernel for new/lost masks; 0 disables
+    gm_thresh_method: str = "otsu"  # "otsu" | "percentile"
+    gm_thresh_percentile: float = 99.0
+    gm_close_kernel: int = 3  # closing kernel size; 0 disables
+    gm_dilate_kernel: int = 0  # dilation kernel size; 0 disables
     use_file_timestamps: bool = True
     normalize: bool = True
     subtract_background: bool = False


### PR DESCRIPTION
## Summary
- derive green/magenta masks from LAB `a` channel with adaptive Otsu or percentile thresholds
- clean masks with configurable morphological closing and dilation
- expose `gm_thresh_method`, `gm_thresh_percentile`, `gm_close_kernel`, and `gm_dilate_kernel` in configuration and document defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c493939bd88324bf8e31444da1428d