### PR TITLE
Improve gain/loss detection with dilated mask overlap

### DIFF
--- a/tests/test_misregistration_tolerance.py
+++ b/tests/test_misregistration_tolerance.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.core import processing
+from app.core.processing import analyze_sequence
+
+
+def create_shifted_frames(tmp_path, dx, dy):
+    base = np.zeros((32, 32), dtype=np.uint8)
+    cv2.rectangle(base, (5, 5), (15, 15), 255, -1)
+    img0 = base
+    M = np.float32([[1, 0, dx], [0, 1, dy]])
+    img1 = cv2.warpAffine(base, M, (32, 32), flags=cv2.INTER_NEAREST, borderValue=0)
+    p0 = tmp_path / "frame0.png"
+    p1 = tmp_path / "frame1.png"
+    cv2.imwrite(str(p0), img0)
+    cv2.imwrite(str(p1), img1)
+    return [p0, p1]
+
+
+def setup(monkeypatch):
+    def fake_register(ref, mov, model="affine", **kwargs):
+        h, w = ref.shape
+        mask = np.ones((h, w), dtype=np.uint8)
+        return True, np.eye(3, dtype=np.float32), mov, mask
+
+    monkeypatch.setattr(processing, "register_ecc", fake_register)
+    monkeypatch.setattr(processing, "segment", lambda img, **kwargs: (img > 127).astype(np.uint8))
+    reg_cfg = {
+        "initial_radius": 0,
+        "gauss_blur_sigma": 0,
+        "clahe_clip": 0,
+        "clahe_grid": 8,
+        "use_masked_ecc": False,
+    }
+    seg_cfg = {}
+    return reg_cfg, seg_cfg
+
+
+@pytest.mark.parametrize(
+    "dx,dy,dilate",
+    [
+        (1, 0, 3),
+        (-1, 0, 3),
+        (0, 1, 3),
+        (0, -1, 3),
+        (2, 0, 5),
+        (-2, 0, 5),
+        (0, 2, 5),
+        (0, -2, 5),
+    ],
+)
+def test_misregistration_tolerance(tmp_path, monkeypatch, dx, dy, dilate):
+    paths = create_shifted_frames(tmp_path, dx, dy)
+    reg_cfg, seg_cfg = setup(monkeypatch)
+    app_cfg = {
+        "direction": "first-to-last",
+        "save_intermediates": True,
+        "class_dilate_kernel": dilate,
+        "component_min_overlap": 0.5,
+    }
+    out_dir = tmp_path / "out"
+    analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
+    new_mask = cv2.imread(str(out_dir / "diff" / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
+    lost_mask = cv2.imread(str(out_dir / "diff" / "lost" / "0000_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    assert new_mask is not None and not np.any(new_mask)
+    assert lost_mask is not None and not np.any(lost_mask)

--- a/tests/test_new_lost_direction.py
+++ b/tests/test_new_lost_direction.py
@@ -123,16 +123,15 @@ def test_intensity_gain_loss(tmp_path, monkeypatch):
     paths, obj = create_intensity_frames(tmp_path)
     reg_cfg, seg_cfg = setup(monkeypatch)
 
-    # first-to-last: intensity increases -> new region
+    # Intensity-only changes should not be classified as new or lost regions
     new_mask, lost_mask, _ = run_direction(
         paths, reg_cfg, seg_cfg, "first-to-last", tmp_path
     )
-    assert np.array_equal(new_mask, obj)
+    assert np.array_equal(new_mask, np.zeros_like(obj))
     assert np.array_equal(lost_mask, np.zeros_like(obj))
 
-    # last-to-first: intensity decreases -> lost region
     new_mask, lost_mask, _ = run_direction(
         paths, reg_cfg, seg_cfg, "last-to-first", tmp_path
     )
     assert np.array_equal(new_mask, np.zeros_like(obj))
-    assert np.array_equal(lost_mask, obj)
+    assert np.array_equal(lost_mask, np.zeros_like(obj))

--- a/tests/test_overlay_new_lost_colors.py
+++ b/tests/test_overlay_new_lost_colors.py
@@ -46,6 +46,7 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
         "save_intermediates": True,
         "overlay_new_color": (0, 255, 0),
         "overlay_lost_color": (255, 0, 255),
+        "component_min_overlap": 0.75,
     }
 
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- Dilate previous and current segmentation masks before comparison
- Classify gain/loss using connected-component overlap with a configurable minimum ratio
- Add regression tests covering ±1–2px misregistrations and update existing tests for overlap-based rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c495471da88324a3033e4d096630d6