### PR TITLE
Always use difference frame for segmentation preview

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -440,9 +440,6 @@ class MainWindow(QMainWindow):
         # Difference preview
         diff_section = CollapsibleSection("Difference")
         diff_layout = QVBoxLayout()
-        self.use_diff_cb = QCheckBox("Use difference for segmentation")
-        self.use_diff_cb.setChecked(self.app.use_difference_for_seg)
-        diff_layout.addWidget(self.use_diff_cb)
         self.diff_method = QComboBox()
         self.diff_method.addItems(["abs", "lab", "edges"])
         self.diff_method.setCurrentText(self.app.difference_method)
@@ -453,8 +450,6 @@ class MainWindow(QMainWindow):
         self.diff_preview_btn.setEnabled(False)
         self.diff_preview_btn.clicked.connect(self._preview_difference)
         controls.addWidget(self.diff_preview_btn)
-        self.use_diff_cb.toggled.connect(self._persist_settings)
-        self.use_diff_cb.toggled.connect(self._on_params_changed)
         self.diff_method.currentTextChanged.connect(self._persist_settings)
         self.diff_method.currentTextChanged.connect(self._on_params_changed)
 
@@ -843,7 +838,7 @@ class MainWindow(QMainWindow):
             normalize=self.norm_cb.isChecked(),
             subtract_background=self.bg_sub_cb.isChecked(),
             scale_minmax=scale_minmax,
-            use_difference_for_seg=self.use_diff_cb.isChecked(),
+            use_difference_for_seg=True,
             difference_method=self.diff_method.currentText(),
             show_ref_overlay=self.overlay_ref_cb.isChecked(),
             show_mov_overlay=self.overlay_mov_cb.isChecked(),
@@ -930,7 +925,6 @@ class MainWindow(QMainWindow):
         self.dir_combo.setCurrentText(app.direction)
         self.dt_min.setValue(app.minutes_between_frames)
         self.use_ts.setChecked(app.use_file_timestamps)
-        self.use_diff_cb.setChecked(app.use_difference_for_seg)
         self.diff_method.setCurrentText(app.difference_method)
         self.norm_cb.setChecked(app.normalize)
         if app.scale_minmax is not None:
@@ -1318,11 +1312,7 @@ class MainWindow(QMainWindow):
             return
         try:
             _, seg, _ = self._persist_settings()
-
-            if self.use_diff_cb.isChecked():
-                gray = self._diff_gray
-            else:
-                gray = self._reg_warp
+            gray = self._diff_gray
             # Mirror pipeline input handling: pass the raw frame to ``segment`` and
             # only normalize when necessary. ``compute_difference`` and
             # ``imread_gray`` already yield ``uint8`` images, so avoid double
@@ -1336,7 +1326,7 @@ class MainWindow(QMainWindow):
                 method=seg.method,
                 invert=seg.invert,
                 skip_outline=seg.skip_outline,
-                use_diff=self.use_diff_cb.isChecked(),
+                use_diff=True,
                 manual_thresh=seg.manual_thresh,
                 adaptive_block=seg.adaptive_block,
                 adaptive_C=seg.adaptive_C,

--- a/tests/test_segmentation_preview_adaptive.py
+++ b/tests/test_segmentation_preview_adaptive.py
@@ -32,7 +32,6 @@ def test_segmentation_preview_matches_segment_adaptive(tmp_path, monkeypatch):
     win.rm_obj.setValue(0)
     win.rm_holes.setValue(0)
     win.use_clahe.setChecked(False)
-    win.use_diff_cb.setChecked(False)
 
     img = np.array(
         [[10, 11, 12],
@@ -41,7 +40,6 @@ def test_segmentation_preview_matches_segment_adaptive(tmp_path, monkeypatch):
         dtype=np.uint8,
     )
 
-    win._reg_warp = img
     win._diff_gray = img
 
     captured = {}
@@ -60,13 +58,13 @@ def test_segmentation_preview_matches_segment_adaptive(tmp_path, monkeypatch):
         method="adaptive",
         invert=win.invert.isChecked(),
         skip_outline=win.skip_outline.isChecked(),
-        use_diff=win.use_diff_cb.isChecked(),
+        use_diff=True,
         manual_thresh=win.manual_t.value(),
         adaptive_block=win.adaptive_blk.value(),
         adaptive_C=win.adaptive_C.value(),
         local_block=win.local_blk.value(),
-        morph_open_radius=win.open_r.value() or None,
-        morph_close_radius=win.close_r.value() or None,
+        morph_open_radius=win.open_r.value(),
+        morph_close_radius=win.close_r.value(),
         remove_objects_smaller_px=win.rm_obj.value(),
         remove_holes_smaller_px=win.rm_holes.value(),
     )


### PR DESCRIPTION
## Summary
- Always segment the difference image in preview mode and remove the UI toggle
- Persist `use_difference_for_seg` as always true
- Update tests for mandatory difference-based segmentation

## Testing
- `pytest tests/test_segmentation_preview_adaptive.py tests/test_segmentation_ui_controls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55252939883249dc40390c8b242c8