### PR TITLE
Add option to save intermediate images

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -456,7 +456,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
                 remove_holes_smaller_px=int(seg_cfg.get("remove_holes_smaller_px", 64)),
                 use_clahe=bool(seg_cfg.get("use_clahe", False)),
             )
-            if app_cfg.get("save_intermediates", True):
+            if app_cfg.get("save_intermediates", False):
                 cv2.imencode(".png", seg_img)[1].tofile(
                     str(diff_raw_dir / f"{k:04d}_diff.png")
                 )
@@ -589,7 +589,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         }
         rows.append(row)
 
-        if app_cfg.get("save_intermediates", True):
+        if app_cfg.get("save_intermediates", False):
             cv2.imencode('.png', prev_crop)[1].tofile(
                 str(reg_dir / f"{prev_k:04d}_prev.png")
             )

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -65,7 +65,7 @@ class AppParams:
     overlay_lost_color: tuple[int, int, int] = (0, 0, 255)
     save_jpg_quality: int = 95
     save_png: bool = False
-    save_intermediates: bool = True
+    save_intermediates: bool = False
     save_masks: bool = False
     use_difference_for_seg: bool = False  # diff masks saved regardless
     difference_method: str = "abs"

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -632,6 +632,11 @@ class MainWindow(QMainWindow):
         run_box.addWidget(self.mov_idx_spin)
         controls.addLayout(run_box)
 
+        self.save_intermediates = QCheckBox("Save intermediate images")
+        self.save_intermediates.setChecked(self.app.save_intermediates)
+        controls.addWidget(self.save_intermediates)
+        self.save_intermediates.toggled.connect(self._persist_settings)
+
         controls.addStretch(1)
 
         # Right: viewer
@@ -848,6 +853,7 @@ class MainWindow(QMainWindow):
             overlay_mov_color=self.mov_color,
             overlay_new_color=self.new_color,
             overlay_lost_color=self.lost_color,
+            save_intermediates=self.save_intermediates.isChecked(),
         )
         app.presets_path = self.app.presets_path
         return reg, seg, app
@@ -939,6 +945,7 @@ class MainWindow(QMainWindow):
         self.overlay_mov_cb.setChecked(app.show_mov_overlay)
         self.alpha_slider.setValue(app.overlay_opacity)
         self.overlay_mode_combo.setCurrentText(app.overlay_mode)
+        self.save_intermediates.setChecked(app.save_intermediates)
         self.ref_color = tuple(app.overlay_ref_color)
         self.mov_color = tuple(app.overlay_mov_color)
         self.new_color = tuple(app.overlay_new_color)
@@ -1441,7 +1448,7 @@ class MainWindow(QMainWindow):
         app_cfg = dict(
             direction=app.direction,
             use_difference_for_seg=app.use_difference_for_seg,
-            save_intermediates=True,
+            save_intermediates=app.save_intermediates,
             difference_method=app.difference_method,
             normalize=app.normalize,
             subtract_background=app.subtract_background,

--- a/tests/test_invalid_direction_ui.py
+++ b/tests/test_invalid_direction_ui.py
@@ -25,7 +25,7 @@ def test_invalid_direction_aborts(tmp_path, monkeypatch):
 
     reg = RegParams()
     seg = SegParams()
-    app_params = AppParams(direction="invalid")
+    app_params = AppParams(direction="invalid", save_intermediates=False)
     monkeypatch.setattr(win, "_persist_settings", lambda *a, **k: (reg, seg, app_params))
 
     captured = {}

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -32,7 +32,7 @@ def test_pipeline_logs_direction(tmp_path, monkeypatch, caplog, direction):
 
     reg = RegParams()
     seg = SegParams()
-    app_params = AppParams(direction=direction)
+    app_params = AppParams(direction=direction, save_intermediates=False)
     monkeypatch.setattr(win, "_persist_settings", lambda *a, **k: (reg, seg, app_params))
     monkeypatch.setattr(QThread, "start", lambda self: None)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -116,7 +116,7 @@ def test_presets_path_persist(tmp_path, monkeypatch):
     preset_dir2 = tmp_path / "presets2"
     preset_dir2.mkdir()
     preset_file2 = preset_dir2 / "preset2.json"
-    save_preset(str(preset_file2), RegParams(), SegParams(), AppParams())
+    save_preset(str(preset_file2), RegParams(), SegParams(), AppParams(save_intermediates=False))
 
     def fake_open(parent, caption, dir, filter):
         assert dir == str(preset_dir1)


### PR DESCRIPTION
## Summary
- add "Save intermediate images" checkbox to main window and persist choice
- default `AppParams.save_intermediates` to False and propagate through pipeline
- adjust processing defaults and tests to respect the new option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55d01843c832485a84f7d88408208