### PR TITLE
Add option to archive intermediate images

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. The binary mask is also 
 `binary/` directory. These files are the same difference maps shown in the UI when using the
 **Preview Difference** button.
 
+If `archive_intermediates` is enabled, these folders are zipped and the original
+PNGs removed once processing finishes.
+
 - `diff/new/` — binary masks highlighting regions that newly appear, used for evaluation.
 - `diff/lost/` — binary masks highlighting regions that disappear, used for evaluation.
 

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -66,6 +66,7 @@ class AppParams:
     save_jpg_quality: int = 95
     save_png: bool = False
     save_intermediates: bool = False
+    archive_intermediates: bool = False
     save_masks: bool = False
     use_difference_for_seg: bool = False  # diff masks saved regardless
     difference_method: str = "abs"

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -636,6 +636,11 @@ class MainWindow(QMainWindow):
         controls.addWidget(self.save_intermediates)
         self.save_intermediates.toggled.connect(self._persist_settings)
 
+        self.archive_intermediates = QCheckBox("Archive/delete intermediate images after run")
+        self.archive_intermediates.setChecked(self.app.archive_intermediates)
+        controls.addWidget(self.archive_intermediates)
+        self.archive_intermediates.toggled.connect(self._persist_settings)
+
         controls.addStretch(1)
 
         # Right: viewer
@@ -853,6 +858,7 @@ class MainWindow(QMainWindow):
             overlay_new_color=self.new_color,
             overlay_lost_color=self.lost_color,
             save_intermediates=self.save_intermediates.isChecked(),
+            archive_intermediates=self.archive_intermediates.isChecked(),
         )
         app.presets_path = self.app.presets_path
         return reg, seg, app
@@ -945,6 +951,7 @@ class MainWindow(QMainWindow):
         self.alpha_slider.setValue(app.overlay_opacity)
         self.overlay_mode_combo.setCurrentText(app.overlay_mode)
         self.save_intermediates.setChecked(app.save_intermediates)
+        self.archive_intermediates.setChecked(app.archive_intermediates)
         self.ref_color = tuple(app.overlay_ref_color)
         self.mov_color = tuple(app.overlay_mov_color)
         self.new_color = tuple(app.overlay_new_color)
@@ -1448,6 +1455,7 @@ class MainWindow(QMainWindow):
             direction=app.direction,
             use_difference_for_seg=app.use_difference_for_seg,
             save_intermediates=app.save_intermediates,
+            archive_intermediates=app.archive_intermediates,
             difference_method=app.difference_method,
             normalize=app.normalize,
             subtract_background=app.subtract_background,

--- a/app/workers/pipeline_worker.py
+++ b/app/workers/pipeline_worker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import List, Dict, Any
+import zipfile
+import shutil
 
 from PyQt6.QtCore import QObject, pyqtSignal, QThread
 
@@ -23,6 +25,18 @@ class PipelineWorker(QObject):
         self.app_cfg = app_cfg
         self.out_dir = out_dir
 
+    def _archive_intermediates(self) -> None:
+        subdirs = ["registered", "binary", "diff", "overlay"]
+        for name in subdirs:
+            p = self.out_dir / name
+            if not p.exists():
+                continue
+            zip_path = self.out_dir / f"{name}.zip"
+            with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for file in p.rglob("*.png"):
+                    zf.write(file, file.relative_to(self.out_dir))
+            shutil.rmtree(p)
+
     def run(self):
         try:
             logger.info("Starting processing for %d paths into %s", len(self.paths), self.out_dir)
@@ -36,6 +50,9 @@ class PipelineWorker(QObject):
 
             self.progressed.emit(total, total)
             logger.info("Progressed: %d/%d", total, total)
+
+            if self.app_cfg.get("save_intermediates") and self.app_cfg.get("archive_intermediates"):
+                self._archive_intermediates()
 
             self.finished.emit(str(self.out_dir))
             logger.info("Processing finished: %s", self.out_dir)

--- a/tests/test_archive_intermediates.py
+++ b/tests/test_archive_intermediates.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from pathlib import Path
+import numpy as np
+import cv2
+import pandas as pd
+import zipfile
+
+# Ensure modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.workers.pipeline_worker import PipelineWorker
+
+
+def test_archive_intermediate_dirs(monkeypatch, tmp_path):
+    # Create dummy images so worker has paths
+    img = np.zeros((5, 5), dtype=np.uint8)
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"img_{i}.png"
+        cv2.imwrite(str(p), img)
+        paths.append(p)
+
+    # Stub analyze_sequence to write out intermediate dirs
+    def fake_analyze(paths, reg_cfg, seg_cfg, app_cfg, out_dir):
+        for name in ["registered", "binary", "diff", "overlay"]:
+            d = out_dir / name
+            d.mkdir(parents=True, exist_ok=True)
+            cv2.imwrite(str(d / "dummy.png"), img)
+        return pd.DataFrame()
+
+    monkeypatch.setattr("app.workers.pipeline_worker.analyze_sequence", fake_analyze)
+
+    reg_cfg = {}
+    seg_cfg = {}
+    app_cfg = {"direction": "first-to-last", "save_intermediates": True, "archive_intermediates": True}
+    out_dir = tmp_path / "out"
+    worker = PipelineWorker(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
+    worker.run()
+
+    for name in ["registered", "binary", "diff", "overlay"]:
+        assert not (out_dir / name).exists()
+        zpath = out_dir / f"{name}.zip"
+        assert zpath.exists()
+        with zipfile.ZipFile(zpath) as zf:
+            assert any(member.endswith("dummy.png") for member in zf.namelist())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -48,6 +48,8 @@ def test_settings_persist(tmp_path):
     win.scale_min.setValue(5)
     win.scale_max.setValue(100)
     win.bg_sub_cb.setChecked(True)
+    win.save_intermediates.setChecked(True)
+    win.archive_intermediates.setChecked(True)
     win.close()
     app.processEvents()
 
@@ -80,6 +82,8 @@ def test_settings_persist(tmp_path):
     assert win2.scale_min.value() == 5
     assert win2.scale_max.value() == 100
     assert win2.bg_sub_cb.isChecked()
+    assert win2.save_intermediates.isChecked()
+    assert win2.archive_intermediates.isChecked()
     win2.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- Add `archive_intermediates` setting and UI checkbox to zip intermediate outputs after runs
- Persist and propagate archiving flag to pipeline worker
- Archive or delete intermediate image folders post-processing
- Document archiving option and expand tests for persistence and cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55fb7baec832486aa68a6a5399ffb