### PR TITLE
Compute and persist gain/loss difference masks

### DIFF
--- a/app/core/evaluation.py
+++ b/app/core/evaluation.py
@@ -40,14 +40,15 @@ def evaluate_diff_masks(
 ) -> pd.DataFrame:
     """Evaluate binary difference masks.
 
-    This function scans ``diff_dir`` for ``bw``, ``new`` and ``lost`` subfolders
-    produced by :func:`app.core.processing.analyze_sequence`. For each frame
+    This function scans ``diff_dir`` for ``bw``, ``gain`` and ``loss`` subfolders
+    produced by :func:`app.core.processing.analyze_sequence`. When the older
+    ``new``/``lost`` folders are present they are used instead. For each frame
     interval it loads the corresponding masks and computes simple area metrics.
 
     Parameters
     ----------
     diff_dir : Path
-        Directory containing ``bw``, ``new`` and ``lost`` subdirectories.
+        Directory containing ``bw`` and ``gain``/``loss`` subdirectories.
     csv_path : Path | str | None, optional
         When provided, the resulting :class:`pandas.DataFrame` is written to this
         CSV file. Relative paths are resolved inside ``diff_dir``.
@@ -62,6 +63,8 @@ def evaluate_diff_masks(
     bw_dir = diff_dir / "bw"
     new_dir = diff_dir / "new"
     lost_dir = diff_dir / "lost"
+    gain_dir = diff_dir / "gain"
+    loss_dir = diff_dir / "loss"
 
     bw_map: Dict[int, Path] = {}
     new_map: Dict[int, Path] = {}
@@ -70,10 +73,18 @@ def evaluate_diff_masks(
     if bw_dir.exists():
         for p in bw_dir.glob("*.png"):
             bw_map[_index_from_name(p)] = p
-    if new_dir.exists():
+
+    if gain_dir.exists():
+        for p in gain_dir.glob("*.png"):
+            new_map[_index_from_name(p)] = p
+    elif new_dir.exists():
         for p in new_dir.glob("*.png"):
             new_map[_index_from_name(p)] = p
-    if lost_dir.exists():
+
+    if loss_dir.exists():
+        for p in loss_dir.glob("*.png"):
+            lost_map[_index_from_name(p)] = p
+    elif lost_dir.exists():
         for p in lost_dir.glob("*.png"):
             lost_map[_index_from_name(p)] = p
 

--- a/tests/test_diff_evaluation.py
+++ b/tests/test_diff_evaluation.py
@@ -15,6 +15,8 @@ def create_masks(tmp_path: Path) -> Path:
     (diff_dir / "bw").mkdir(parents=True)
     (diff_dir / "new").mkdir(parents=True)
     (diff_dir / "lost").mkdir(parents=True)
+    (diff_dir / "gain").mkdir(parents=True)
+    (diff_dir / "loss").mkdir(parents=True)
 
     new_mask = np.zeros((4, 4), dtype=np.uint8)
     new_mask[0, 0] = 255
@@ -31,6 +33,8 @@ def create_masks(tmp_path: Path) -> Path:
     cv2.imwrite(str(diff_dir / "new" / "0000_bw_new.png"), new_mask)
     cv2.imwrite(str(diff_dir / "lost" / "0000_bw_lost.png"), lost_mask)
     cv2.imwrite(str(diff_dir / "bw" / "0001_bw_diff.png"), diff_mask)
+    cv2.imwrite(str(diff_dir / "gain" / "0000_bw_gain.png"), cv2.bitwise_and(new_mask, diff_mask))
+    cv2.imwrite(str(diff_dir / "loss" / "0000_bw_loss.png"), cv2.bitwise_and(lost_mask, diff_mask))
     return diff_dir
 
 

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -60,6 +60,8 @@ def test_difference_output(tmp_path, monkeypatch):
     assert (bw_dir / "0001_bw_diff.png").exists()
     assert (diff_dir / "new" / "0000_bw_new.png").exists()
     assert (diff_dir / "lost" / "0000_bw_lost.png").exists()
+    assert (diff_dir / "gain" / "0000_bw_gain.png").exists()
+    assert (diff_dir / "loss" / "0000_bw_loss.png").exists()
 
     reg0 = cv2.imread(str(out_dir / "mask_0000_registered.png"), cv2.IMREAD_GRAYSCALE)
     reg1 = cv2.imread(str(out_dir / "mask_0001_registered.png"), cv2.IMREAD_GRAYSCALE)

--- a/tests/test_evaluate_diff_masks.py
+++ b/tests/test_evaluate_diff_masks.py
@@ -14,6 +14,8 @@ def create_masks(tmp_path: Path) -> Path:
     (diff_dir / "bw").mkdir(parents=True)
     (diff_dir / "new").mkdir(parents=True)
     (diff_dir / "lost").mkdir(parents=True)
+    (diff_dir / "gain").mkdir(parents=True)
+    (diff_dir / "loss").mkdir(parents=True)
 
     new_mask = np.zeros((4, 4), dtype=np.uint8)
     new_mask[0, 0] = 255
@@ -30,6 +32,8 @@ def create_masks(tmp_path: Path) -> Path:
     cv2.imwrite(str(diff_dir / "new" / "0000_bw_new.png"), new_mask)
     cv2.imwrite(str(diff_dir / "lost" / "0000_bw_lost.png"), lost_mask)
     cv2.imwrite(str(diff_dir / "bw" / "0001_bw_diff.png"), diff_mask)
+    cv2.imwrite(str(diff_dir / "gain" / "0000_bw_gain.png"), cv2.bitwise_and(new_mask, diff_mask))
+    cv2.imwrite(str(diff_dir / "loss" / "0000_bw_loss.png"), cv2.bitwise_and(lost_mask, diff_mask))
     return diff_dir
 
 

--- a/tests/test_misregistration_tolerance.py
+++ b/tests/test_misregistration_tolerance.py
@@ -63,12 +63,13 @@ def test_misregistration_tolerance(tmp_path, monkeypatch, dx, dy, dilate):
     app_cfg = {
         "direction": "first-to-last",
         "save_intermediates": True,
+        "save_masks": True,
         "class_dilate_kernel": dilate,
         "component_min_overlap": 0.5,
     }
     out_dir = tmp_path / "out"
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
-    new_mask = cv2.imread(str(out_dir / "diff" / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
-    lost_mask = cv2.imread(str(out_dir / "diff" / "lost" / "0000_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    new_mask = cv2.imread(str(out_dir / "diff" / "gain" / "0000_bw_gain.png"), cv2.IMREAD_GRAYSCALE)
+    lost_mask = cv2.imread(str(out_dir / "diff" / "loss" / "0000_bw_loss.png"), cv2.IMREAD_GRAYSCALE)
     assert new_mask is not None and not np.any(new_mask)
     assert lost_mask is not None and not np.any(lost_mask)

--- a/tests/test_new_lost_direction.py
+++ b/tests/test_new_lost_direction.py
@@ -71,6 +71,7 @@ def run_direction(paths, reg_cfg, seg_cfg, direction, tmp_path):
     app_cfg = {
         "direction": direction,
         "save_intermediates": True,
+        "save_masks": True,
         "overlay_new_color": (0, 255, 0),
         "overlay_lost_color": (255, 0, 255),
     }
@@ -78,11 +79,11 @@ def run_direction(paths, reg_cfg, seg_cfg, direction, tmp_path):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
     prev_idx = 0 if direction == "first-to-last" else 1
     new_mask = cv2.imread(
-        str(out_dir / "diff" / "new" / f"{prev_idx:04d}_bw_new.png"),
+        str(out_dir / "diff" / "gain" / f"{prev_idx:04d}_bw_gain.png"),
         cv2.IMREAD_GRAYSCALE,
     )
     lost_mask = cv2.imread(
-        str(out_dir / "diff" / "lost" / f"{prev_idx:04d}_bw_lost.png"),
+        str(out_dir / "diff" / "loss" / f"{prev_idx:04d}_bw_loss.png"),
         cv2.IMREAD_GRAYSCALE,
     )
     overlay = cv2.imread(str(out_dir / "overlay" / f"{prev_idx:04d}_overlay_mov.png"))

--- a/tests/test_overlay_frame_alignment.py
+++ b/tests/test_overlay_frame_alignment.py
@@ -53,6 +53,7 @@ def test_overlay_frame_alignment(tmp_path, monkeypatch):
     app_cfg = {
         "direction": "first-to-last",
         "save_intermediates": True,
+        "save_masks": True,
     }
 
     out_dir = tmp_path / "out"
@@ -63,10 +64,12 @@ def test_overlay_frame_alignment(tmp_path, monkeypatch):
 
     # Appearance between frame0 and frame1 should be attributed to frame0
     assert (overlay_dir / "0000_overlay_mov.png").exists()
-    bw_new = cv2.imread(str(diff_dir / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
+    assert (diff_dir / "new" / "0000_bw_new.png").exists()
+    bw_new = cv2.imread(str(diff_dir / "gain" / "0000_bw_gain.png"), cv2.IMREAD_GRAYSCALE)
     assert bw_new is not None and np.any(bw_new)
 
     # Disappearance between frame1 and frame2 should be attributed to frame1
     assert (overlay_dir / "0001_overlay_mov.png").exists()
-    bw_lost = cv2.imread(str(diff_dir / "lost" / "0001_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    assert (diff_dir / "lost" / "0001_bw_lost.png").exists()
+    bw_lost = cv2.imread(str(diff_dir / "loss" / "0001_bw_loss.png"), cv2.IMREAD_GRAYSCALE)
     assert bw_lost is not None and np.any(bw_lost)

--- a/tests/test_overlay_new_lost_colors.py
+++ b/tests/test_overlay_new_lost_colors.py
@@ -44,6 +44,7 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
     app_cfg = {
         "direction": "first-to-last",
         "save_intermediates": True,
+        "save_masks": True,
         "overlay_new_color": (0, 255, 0),
         "overlay_lost_color": (255, 0, 255),
         "component_min_overlap": 0.75,
@@ -59,8 +60,8 @@ def test_overlay_contains_new_and_lost_colors(tmp_path, monkeypatch):
     assert (overlay_img == green).all(axis=2).any()
     assert (overlay_img == magenta).all(axis=2).any()
 
-    bw_new = cv2.imread(str(out_dir / "diff" / "new" / "0000_bw_new.png"), cv2.IMREAD_GRAYSCALE)
-    bw_lost = cv2.imread(str(out_dir / "diff" / "lost" / "0000_bw_lost.png"), cv2.IMREAD_GRAYSCALE)
+    bw_new = cv2.imread(str(out_dir / "diff" / "gain" / "0000_bw_gain.png"), cv2.IMREAD_GRAYSCALE)
+    bw_lost = cv2.imread(str(out_dir / "diff" / "loss" / "0000_bw_loss.png"), cv2.IMREAD_GRAYSCALE)
 
     mask0 = cv2.imread(str(paths[0]), cv2.IMREAD_GRAYSCALE)
     mask1 = cv2.imread(str(paths[1]), cv2.IMREAD_GRAYSCALE)


### PR DESCRIPTION
## Summary
- Derive gain and loss masks by intersecting new/lost regions with the raw difference mask
- Persist new, lost, gain, and loss masks under diff/ with `save_masks` and overlay gain/loss regions
- Extend mask evaluation to read gain/loss folders and add regression tests for the new outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56a2fc7ac83249ef54521125c2c14