### PR TITLE
Add options to save diff masks and GM composites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ If your OpenCV is CUDA-enabled, the app will automatically use it for some ops (
 Otherwise it runs on CPU with multi-processing. To install a CUDA wheel, consider prebuilt packages from
 `opencv-python` ecosystem or build from source with CUDA. The code checks `cv2.cuda` presence.
 
+### Run Analysis
+After selecting an image folder and setting parameters, click **Run Analysis** to process the
+time-lapse sequence. Output controls provide several options:
+
+- **Save intermediate images** – store registration and segmentation artifacts.
+- **Archive/delete intermediate images after run** – zip and remove intermediate images when finished.
+- **Save difference masks** – write thresholded difference masks for each frame pair.
+- **Save GM composites** – save green/magenta composite images alongside the outputs.
+
 ### Intermediate outputs
 When `save_intermediates` is enabled, the pipeline saves additional artifacts alongside the final results.
 For every pair of frames a raw difference (`{frame}_diff.png`) is written to `diff/raw/` and its

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -67,8 +67,8 @@ class AppParams:
     save_png: bool = False
     save_intermediates: bool = False
     archive_intermediates: bool = False
-    save_masks: bool = False
-    save_gm_composite: bool = False
+    save_masks: bool = False  # save difference masks
+    save_gm_composite: bool = False  # save green/magenta composites
     use_difference_for_seg: bool = False  # diff masks saved regardless
     difference_method: str = "abs"
     gm_thresh_method: str = "otsu"  # "otsu" | "percentile"

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -641,6 +641,16 @@ class MainWindow(QMainWindow):
         controls.addWidget(self.archive_intermediates)
         self.archive_intermediates.toggled.connect(self._persist_settings)
 
+        self.save_masks_checkbox = QCheckBox("Save difference masks")
+        self.save_masks_checkbox.setChecked(self.app.save_masks)
+        controls.addWidget(self.save_masks_checkbox)
+        self.save_masks_checkbox.toggled.connect(self._persist_settings)
+
+        self.save_gm_checkbox = QCheckBox("Save GM composites")
+        self.save_gm_checkbox.setChecked(self.app.save_gm_composite)
+        controls.addWidget(self.save_gm_checkbox)
+        self.save_gm_checkbox.toggled.connect(self._persist_settings)
+
         controls.addStretch(1)
 
         # Right: viewer
@@ -859,6 +869,8 @@ class MainWindow(QMainWindow):
             overlay_lost_color=self.lost_color,
             save_intermediates=self.save_intermediates.isChecked(),
             archive_intermediates=self.archive_intermediates.isChecked(),
+            save_masks=self.save_masks_checkbox.isChecked(),
+            save_gm_composite=self.save_gm_checkbox.isChecked(),
         )
         app.presets_path = self.app.presets_path
         return reg, seg, app
@@ -1456,6 +1468,8 @@ class MainWindow(QMainWindow):
             use_difference_for_seg=app.use_difference_for_seg,
             save_intermediates=app.save_intermediates,
             archive_intermediates=app.archive_intermediates,
+            save_masks=self.save_masks_checkbox.isChecked(),
+            save_gm_composite=self.save_gm_checkbox.isChecked(),
             difference_method=app.difference_method,
             normalize=app.normalize,
             subtract_background=app.subtract_background,


### PR DESCRIPTION
## Summary
- Add checkboxes to main window to save difference masks and green/magenta composites
- Persist new save options in AppParams and pipeline configuration
- Document Run Analysis output controls in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c56f465e3483249f9f3f49460e9bc0