### PR TITLE
Remove obsolete binary intermediate outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ time-lapse sequence. Output controls provide several options:
 ### Intermediate outputs
 When `save_intermediates` is enabled, the pipeline saves additional artifacts alongside the final results.
 For every pair of frames a raw difference (`{frame}_diff.png`) is written to `diff/raw/` and its
-thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. The binary mask is also duplicated in the
-`binary/` directory. These files are the same difference maps shown in the UI when using the
-**Preview Difference** button.
+thresholded mask (`{frame}_bw_diff.png`) to `diff/bw/`. These files are the same difference maps
+shown in the UI when using the **Preview Difference** button.
 
 If `archive_intermediates` is enabled, these folders are zipped and the original
 PNGs removed once processing finishes.

--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -209,12 +209,6 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     ensure_dir(out_dir)
     reg_dir = out_dir / "registered"; ensure_dir(reg_dir)
 
-    bw_dir = out_dir / "binary"; ensure_dir(bw_dir)
-    bw_mov_dir = bw_dir / "mov"; ensure_dir(bw_mov_dir)
-    bw_prev_dir = bw_dir / "prev"; ensure_dir(bw_prev_dir)
-    bw_overlap_dir = bw_dir / "overlap"; ensure_dir(bw_overlap_dir)
-    bw_empty_dir = bw_dir / "empty"; ensure_dir(bw_empty_dir)
-
     diff_dir = out_dir / "diff"; ensure_dir(diff_dir)
     diff_raw_dir = diff_dir / "raw"; ensure_dir(diff_raw_dir)
     diff_bw_dir = diff_dir / "bw"; ensure_dir(diff_bw_dir)
@@ -521,9 +515,6 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             logger.warning(
                 "Frame %d: segmentation mask is empty; skipping ecc_mask update", k
             )
-            cv2.imencode(".png", (seg_mask * 255).astype(np.uint8))[1].tofile(
-                str(bw_empty_dir / f"{k:04d}_bw_mov_empty.png")
-            )
         else:
             all_masks_empty = False
             ecc_mask = seg_mask.copy()
@@ -633,22 +624,6 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             )
             cv2.imencode('.png', mov_crop)[1].tofile(
                 str(reg_dir / f"{k:04d}_mov.png")
-            )
-            cv2.imencode('.png', (seg_mask * 255).astype(np.uint8))[1].tofile(
-                str(bw_mov_dir / f"{k:04d}_bw_mov.png")
-            )
-            if bw_diff is not None:
-                cv2.imencode('.png', (bw_reg * 255).astype(np.uint8))[1].tofile(
-                    str(bw_dir / f"{k:04d}_bw_reg.png")
-                )
-                cv2.imencode('.png', (bw_diff * 255).astype(np.uint8))[1].tofile(
-                    str(bw_dir / f"{k:04d}_bw_diff.png")
-                )
-            cv2.imencode('.png', (prev_bw_crop * 255).astype(np.uint8))[1].tofile(
-                str(bw_prev_dir / f"{prev_k:04d}_bw_prev.png")
-            )
-            cv2.imencode('.png', (bw_overlap * 255).astype(np.uint8))[1].tofile(
-                str(bw_overlap_dir / f"{prev_k:04d}_bw_overlap.png")
             )
             if idx > 0:
                 new_color = tuple(app_cfg.get("overlay_new_color", (0, 255, 0)))

--- a/app/workers/pipeline_worker.py
+++ b/app/workers/pipeline_worker.py
@@ -26,7 +26,7 @@ class PipelineWorker(QObject):
         self.out_dir = out_dir
 
     def _archive_intermediates(self) -> None:
-        subdirs = ["registered", "binary", "diff", "overlay"]
+        subdirs = ["registered", "diff", "overlay"]
         for name in subdirs:
             p = self.out_dir / name
             if not p.exists():

--- a/tests/test_archive_intermediates.py
+++ b/tests/test_archive_intermediates.py
@@ -23,7 +23,7 @@ def test_archive_intermediate_dirs(monkeypatch, tmp_path):
 
     # Stub analyze_sequence to write out intermediate dirs
     def fake_analyze(paths, reg_cfg, seg_cfg, app_cfg, out_dir):
-        for name in ["registered", "binary", "diff", "overlay"]:
+        for name in ["registered", "diff", "overlay"]:
             d = out_dir / name
             d.mkdir(parents=True, exist_ok=True)
             cv2.imwrite(str(d / "dummy.png"), img)
@@ -38,7 +38,7 @@ def test_archive_intermediate_dirs(monkeypatch, tmp_path):
     worker = PipelineWorker(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
     worker.run()
 
-    for name in ["registered", "binary", "diff", "overlay"]:
+    for name in ["registered", "diff", "overlay"]:
         assert not (out_dir / name).exists()
         zpath = out_dir / f"{name}.zip"
         assert zpath.exists()

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -54,10 +54,8 @@ def test_difference_output(tmp_path, monkeypatch):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     diff_dir = out_dir / "diff"
-    bw_dir = out_dir / "binary"
     assert (diff_dir / "raw" / "0001_diff.png").exists()
     assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
-    assert (bw_dir / "0001_bw_diff.png").exists()
     assert (diff_dir / "new" / "0000_bw_new.png").exists()
     assert (diff_dir / "lost" / "0000_bw_lost.png").exists()
     assert (diff_dir / "gain" / "0000_bw_gain.png").exists()
@@ -101,7 +99,5 @@ def test_difference_output_disabled(tmp_path, monkeypatch):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     diff_dir = out_dir / "diff"
-    bw_dir = out_dir / "binary"
     assert (diff_dir / "raw" / "0001_diff.png").exists()
     assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
-    assert (bw_dir / "0001_bw_diff.png").exists()

--- a/tests/test_empty_mask_warning.py
+++ b/tests/test_empty_mask_warning.py
@@ -66,8 +66,6 @@ def test_warns_and_skips_ecc_mask(tmp_path, caplog):
         df = analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     assert any("segmentation mask is empty" in rec.message for rec in caplog.records)
-    empty_mask_path = out_dir / "binary" / "empty" / "0001_bw_mov_empty.png"
-    assert empty_mask_path.exists()
     row = df[df["frame_index"] == 1].iloc[0]
     assert row["area_mov_px"] == 0
 


### PR DESCRIPTION
## Summary
- drop generation of `binary/` intermediates and write masks only to existing diff or overlay directories
- stop archiving now-removed `binary` path
- refresh tests and docs to reflect simplified outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ad9e43308324af7e9811cccf4bba