### PR TITLE
Refactor intermediate archiving

### DIFF
--- a/app/workers/pipeline_worker.py
+++ b/app/workers/pipeline_worker.py
@@ -12,6 +12,11 @@ from ..core.io_utils import ensure_dir
 
 logger = logging.getLogger(__name__)
 
+# Intermediate subdirectories that should be archived after a run.
+# The previous "binary" output has been removed, so it is omitted here.
+ARCHIVE_SUBDIRS = ("registered", "diff", "overlay")
+
+
 class PipelineWorker(QObject):
     progressed = pyqtSignal(int, int)  # current, total (reserved for future granular progress)
     finished = pyqtSignal(str)         # output dir
@@ -26,8 +31,7 @@ class PipelineWorker(QObject):
         self.out_dir = out_dir
 
     def _archive_intermediates(self) -> None:
-        subdirs = ["registered", "diff", "overlay"]
-        for name in subdirs:
+        for name in ARCHIVE_SUBDIRS:
             p = self.out_dir / name
             if not p.exists():
                 continue


### PR DESCRIPTION
## Summary
- centralize list of intermediate directories to archive
- ensure binary intermediates are no longer archived

## Testing
- `pytest tests/test_archive_intermediates.py::test_archive_intermediate_dirs -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af1c9f7c8324beb58b5bc3d097dc