### PR TITLE
Add tooltips for intermediate image options

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -632,21 +632,35 @@ class MainWindow(QMainWindow):
         controls.addLayout(run_box)
 
         self.save_intermediates = QCheckBox("Save intermediate images")
+        self.save_intermediates.setToolTip(
+            "Store registration and segmentation frames for debugging."
+        )
         self.save_intermediates.setChecked(self.app.save_intermediates)
         controls.addWidget(self.save_intermediates)
         self.save_intermediates.toggled.connect(self._persist_settings)
 
-        self.archive_intermediates = QCheckBox("Archive/delete intermediate images after run")
+        self.archive_intermediates = QCheckBox(
+            "Archive/delete intermediate images after run"
+        )
+        self.archive_intermediates.setToolTip(
+            "After completion, move intermediate files to archive or delete them."
+        )
         self.archive_intermediates.setChecked(self.app.archive_intermediates)
         controls.addWidget(self.archive_intermediates)
         self.archive_intermediates.toggled.connect(self._persist_settings)
 
         self.save_masks_checkbox = QCheckBox("Save difference masks")
+        self.save_masks_checkbox.setToolTip(
+            "Export binary difference masks for each frame."
+        )
         self.save_masks_checkbox.setChecked(self.app.save_masks)
         controls.addWidget(self.save_masks_checkbox)
         self.save_masks_checkbox.toggled.connect(self._persist_settings)
 
         self.save_gm_checkbox = QCheckBox("Save GM composites")
+        self.save_gm_checkbox.setToolTip(
+            "Save composite images of growth measurement (GM) results."
+        )
         self.save_gm_checkbox.setChecked(self.app.save_gm_composite)
         controls.addWidget(self.save_gm_checkbox)
         self.save_gm_checkbox.toggled.connect(self._persist_settings)


### PR DESCRIPTION
## Summary
- add descriptive tooltips to intermediate image and mask saving options in the main UI

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt6.QtWidgets import QApplication
from app.ui.main_window import MainWindow
app = QApplication([])
win = MainWindow()
print('save_intermediates tooltip:', win.save_intermediates.toolTip())
print('archive_intermediates tooltip:', win.archive_intermediates.toolTip())
print('save_masks_checkbox tooltip:', win.save_masks_checkbox.toolTip())
print('save_gm_checkbox tooltip:', win.save_gm_checkbox.toolTip())
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b38ef7d08324bff0006042b0e93a