### PR TITLE
Allow collapsible sections to start collapsed

### DIFF
--- a/app/ui/collapsible_section.py
+++ b/app/ui/collapsible_section.py
@@ -7,20 +7,26 @@ from PyQt6.QtWidgets import QWidget, QVBoxLayout, QToolButton, QLayout
 class CollapsibleSection(QWidget):
     """A simple collapsible container with a toggle header."""
 
-    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+    def __init__(
+        self, title: str, parent: QWidget | None = None, collapsed: bool = False
+    ) -> None:
         super().__init__(parent)
         self._button = QToolButton(self)
         self._button.setText(title)
         self._button.setCheckable(True)
-        self._button.setChecked(True)
+        self._button.setChecked(not collapsed)
         self._button.setToolButtonStyle(
             Qt.ToolButtonStyle.ToolButtonTextBesideIcon
         )
-        self._button.setArrowType(Qt.ArrowType.DownArrow)
+        self._button.setArrowType(
+            Qt.ArrowType.DownArrow
+            if not collapsed
+            else Qt.ArrowType.RightArrow
+        )
         self._button.clicked.connect(self._on_toggled)
 
         self._content = QWidget(self)
-        self._content.setVisible(True)
+        self._content.setVisible(not collapsed)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -229,7 +229,7 @@ class MainWindow(QMainWindow):
         self.bg_sub_cb.toggled.connect(self._on_params_changed)
 
         # Registration params
-        reg_section = CollapsibleSection("Registration")
+        reg_section = CollapsibleSection("Registration", collapsed=True)
         reg_grid = QGridLayout()
         self.reg_method = QComboBox()
         self.reg_method.addItems(["ECC", "ORB", "ORB+ECC"])
@@ -437,7 +437,7 @@ class MainWindow(QMainWindow):
         self._on_reg_method_change(self.reg_method.currentText())
 
         # Difference preview
-        diff_section = CollapsibleSection("Difference")
+        diff_section = CollapsibleSection("Difference", collapsed=True)
         diff_layout = QVBoxLayout()
         self.diff_method = QComboBox()
         self.diff_method.addItems(["abs", "lab", "edges"])
@@ -453,7 +453,7 @@ class MainWindow(QMainWindow):
         self.diff_method.currentTextChanged.connect(self._on_params_changed)
 
         # Segmentation params
-        seg_section = CollapsibleSection("Segmentation")
+        seg_section = CollapsibleSection("Segmentation", collapsed=True)
         seg_grid = QGridLayout()
         self.seg_method = QComboBox()
         self.seg_method.addItems(


### PR DESCRIPTION
## Summary
- add optional `collapsed` parameter to `CollapsibleSection` for controlling initial state
- start registration, difference and segmentation panels collapsed in the main window

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b5ab7fd08324907a51786a00f7c0