### PR TITLE
Add gain/loss detection preview controls

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -99,6 +99,8 @@ def _detect_green_magenta(
 
     lab = cv2.cvtColor(gm_composite, cv2.COLOR_BGR2LAB)
     a_channel = lab[..., 1].astype(np.int16) - 128  # center at 0
+    sat = float(app_cfg.get("gm_saturation", 1.0))
+    a_channel = np.clip(a_channel * sat, -255, 255).astype(np.int16)
     abs_a = np.abs(a_channel).astype(np.uint8)
 
     thresh_method = str(app_cfg.get("gm_thresh_method", "otsu")).lower()


### PR DESCRIPTION
## Summary
- Expose gain/loss detection parameters (threshold method, percentile, morphology, saturation) in the Segmentation panel
- Add gain/loss preview that overlays green/magenta masks on a composite image
- Support new gm_saturation option in configuration and processing helpers

## Testing
- `python3 -m py_compile app/models/config.py app/core/processing.py app/ui/main_window.py`
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bd014c448324bca98cfd13f5837d