### PR TITLE
Add gm_opacity parameter for green-magenta composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@ All notable changes to this project will be documented in this file.
 - Usage notes: Yen excels on low-contrast backgrounds, while Multi-Otsu is suited for images with distinct histogram peaks.
 
 ### Changed
-- Green–magenta composite now blends frames using `overlay_opacity` to weight the current frame.
+- Green–magenta composite now blends frames using `gm_opacity` to weight the current frame.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ PNGs removed once processing finishes.
 The separation between the magenta and green channels is determined in LAB
 color space using an adaptive threshold on the "a" channel. The composite
 itself blends the current frame with the previous according to
-`overlay_opacity` (percentage of the current frame, default `50`).  By default
+`gm_opacity` (percentage of the current frame, default `50`).  By default
 an Otsu threshold (`gm_thresh_method="otsu"`) is used, but a percentile
 (`gm_thresh_percentile`, default `99.0`) can be selected instead.  To remove
 speckles and recover full structures the masks are optionally processed with

--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -71,7 +71,7 @@ def _detect_green_magenta(
     The ``gm_composite`` image encodes a weighted blend of the previous frame
     in the green channel and the current frame in red/blue (magenta).  The
     blending weight ``alpha`` is derived from
-    ``app_cfg['overlay_opacity']`` (percentage of the current frame, default
+    ``app_cfg['gm_opacity']`` (percentage of the current frame, default
     ``50``) such that the previous frame contributes ``1 - alpha``. Depending on
     ``direction`` the roles of these colors are swapped so that ``green`` always
     represents the frame that is considered "lost" and ``magenta`` the frame
@@ -222,7 +222,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
     overlay_dir = out_dir / "overlay"; ensure_dir(overlay_dir)
 
-    overlay_opacity = int(app_cfg.get("overlay_opacity", 50))
+    gm_opacity = int(app_cfg.get("gm_opacity", 50))
 
     rows: List[Dict] = []
 
@@ -422,8 +422,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         mov_crop = warped[y_k:y_k + h_k, x_k:x_k + w_k]
 
         # Create a green‑magenta composite to highlight differences, blending
-        # the frames according to ``overlay_opacity``.
-        alpha = overlay_opacity / 100.0
+        # the frames according to ``gm_opacity``.
+        alpha = gm_opacity / 100.0
         gm_composite = np.zeros((h_k, w_k, 3), dtype=np.uint8)
         gm_composite[..., 1] = (prev_crop * (1 - alpha)).astype(np.uint8)
         gm_composite[..., 0] = gm_composite[..., 2] = (

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -57,12 +57,13 @@ class AppParams:
     direction: str = "last-to-first"  # "last-to-first" | "first-to-last"
     show_ref_overlay: bool = True
     show_mov_overlay: bool = True
-    overlay_opacity: int = 50  # 0-100 weight of current frame in green/magenta overlays
+    overlay_opacity: int = 50  # 0-100 weight of moving frame in registration overlay
     overlay_mode: str = "magenta-green"
     overlay_ref_color: tuple[int, int, int] = (0, 255, 0)
     overlay_mov_color: tuple[int, int, int] = (255, 0, 255)
     overlay_new_color: tuple[int, int, int] = (0, 255, 0)
     overlay_lost_color: tuple[int, int, int] = (0, 0, 255)
+    gm_opacity: int = 50  # 0-100 weight of current frame in green/magenta composites
     save_jpg_quality: int = 95
     save_png: bool = False
     save_intermediates: bool = False
@@ -93,6 +94,7 @@ def load_preset(path: str) -> tuple[RegParams, SegParams, AppParams]:
         data = json.load(f)
     app_data = data["app"]
     app_data.setdefault("gm_saturation", 1.0)
+    app_data.setdefault("gm_opacity", app_data.get("overlay_opacity", 50))
     return RegParams(**data["reg"]), SegParams(**data["seg"]), AppParams(**app_data)
 
 def save_settings(reg: RegParams, seg: SegParams, app: AppParams) -> None:
@@ -112,6 +114,7 @@ def load_settings() -> tuple[RegParams, SegParams, AppParams]:
             data = json.loads(v)
             if cls is AppParams:
                 data.setdefault("gm_saturation", 1.0)
+                data.setdefault("gm_opacity", data.get("overlay_opacity", 50))
             return cls(**data)
         except Exception:
             return default

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -762,7 +762,7 @@ class MainWindow(QMainWindow):
         self.overlay_mov_cb.setChecked(self.app.show_mov_overlay)
         self.alpha_slider = QSlider(Qt.Orientation.Horizontal)
         self.alpha_slider.setRange(0, 100)
-        self.alpha_slider.setValue(self.app.overlay_opacity)
+        self.alpha_slider.setValue(self.app.gm_opacity)
         overlay_box.addWidget(self.overlay_ref_cb)
         overlay_box.addWidget(self.overlay_mov_cb)
         overlay_box.addWidget(QLabel("Opacity"))
@@ -948,6 +948,7 @@ class MainWindow(QMainWindow):
             show_ref_overlay=self.overlay_ref_cb.isChecked(),
             show_mov_overlay=self.overlay_mov_cb.isChecked(),
             overlay_opacity=self.alpha_slider.value(),
+            gm_opacity=self.alpha_slider.value(),
             overlay_mode=self.overlay_mode_combo.currentText(),
             overlay_ref_color=self.ref_color,
             overlay_mov_color=self.mov_color,
@@ -1056,7 +1057,7 @@ class MainWindow(QMainWindow):
         self.scale_max.setEnabled(self.norm_cb.isChecked())
         self.overlay_ref_cb.setChecked(app.show_ref_overlay)
         self.overlay_mov_cb.setChecked(app.show_mov_overlay)
-        self.alpha_slider.setValue(app.overlay_opacity)
+        self.alpha_slider.setValue(app.gm_opacity)
         self.overlay_mode_combo.setCurrentText(app.overlay_mode)
         self.save_intermediates.setChecked(app.save_intermediates)
         self.archive_intermediates.setChecked(app.archive_intermediates)
@@ -1517,7 +1518,7 @@ class MainWindow(QMainWindow):
                 remove_holes_smaller_px=seg.remove_holes_smaller_px,
                 use_clahe=seg.use_clahe,
             )
-            alpha = app.overlay_opacity / 100.0
+            alpha = app.gm_opacity / 100.0
             gm_comp = np.zeros((*self._reg_ref.shape, 3), dtype=np.uint8)
             gm_comp[..., 1] = (self._reg_ref * (1 - alpha)).astype(np.uint8)
             gm_comp[..., 0] = gm_comp[..., 2] = (


### PR DESCRIPTION
## Summary
- add `gm_opacity` field to `AppParams` and ensure it persists through presets and settings
- use `gm_opacity` for green-magenta detection and composite generation
- collect and apply `gm_opacity` in UI so the slider value is saved and restored

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c05f57cc832481a6b996429ae1d2