### PR TITLE
Add gain/loss preview tests and persist GM settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
   - `tests/test_segmentation_multi_otsu.py` checks Multi-Otsu segmentation with two classes.
   - `tests/test_segmentation_li.py` verifies Li thresholding.
 - Usage notes: Yen excels on low-contrast backgrounds, while Multi-Otsu is suited for images with distinct histogram peaks.
+- Gain/loss preview adds `gm_saturation` control and persists `gm_opacity`/
+  `gm_saturation` in saved presets and settings.
 
 ### Changed
 - Green–magenta composite now blends frames using `gm_opacity` to weight the current frame.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ PNGs removed once processing finishes.
 The separation between the magenta and green channels is determined in LAB
 color space using an adaptive threshold on the "a" channel. The composite
 itself blends the current frame with the previous according to
-`gm_opacity` (percentage of the current frame, default `50`).  By default
-an Otsu threshold (`gm_thresh_method="otsu"`) is used, but a percentile
-(`gm_thresh_percentile`, default `99.0`) can be selected instead.  To remove
-speckles and recover full structures the masks are optionally processed with
-morphological closing (`gm_close_kernel`, default `3`) and dilation
-(`gm_dilate_kernel`, default `0`).
+`gm_opacity` (percentage of the current frame, default `50`). A saturation
+boost (`gm_saturation`, default `1.0`) scales the chroma channel before
+thresholding to emphasize subtle differences. By default an Otsu threshold
+(`gm_thresh_method="otsu"`) is used, but a percentile (`gm_thresh_percentile`,
+default `99.0`) can be selected instead. To remove speckles and recover full
+structures the masks are optionally processed with morphological closing
+(`gm_close_kernel`, default `3`) and dilation (`gm_dilate_kernel`, default
+`0`).
 
 ### Project layout
 - `app/main.py` — app entry, sets up MainWindow.

--- a/tests/test_gain_loss_preview.py
+++ b/tests/test_gain_loss_preview.py
@@ -1,0 +1,129 @@
+import os
+import sys
+from pathlib import Path
+import numpy as np
+import pyqtgraph as pg
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QSettings
+
+pg.setConfigOptions(useOpenGL=False)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.ui.main_window import MainWindow
+from app.core.processing import _detect_green_magenta as real_detect
+from app.core.segmentation import segment as real_segment
+
+
+def test_gain_loss_preview_matches_detection(tmp_path, monkeypatch):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+
+    win.seg_method.setCurrentText("manual")
+    win.invert.setChecked(False)
+    win.skip_outline.setChecked(True)
+    win.manual_t.setValue(5)
+    win.open_r.setValue(0)
+    win.close_r.setValue(0)
+    win.rm_obj.setValue(0)
+    win.rm_holes.setValue(0)
+    win.use_clahe.setChecked(False)
+    win.alpha_slider.setValue(60)
+    win.gm_sat_slider.setValue(15)
+
+    win._reg_ref = np.array(
+        [[10, 0, 0],
+         [0, 0, 0],
+         [0, 0, 0]],
+        dtype=np.uint8,
+    )
+    win._reg_warp = np.array(
+        [[0, 0, 0],
+         [0, 10, 0],
+         [0, 0, 0]],
+        dtype=np.uint8,
+    )
+
+    captured = {}
+
+    def capture_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction):
+        g, m = real_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction=direction)
+        captured["gm_composite"] = gm_comp
+        captured["prev_seg"] = prev_seg
+        captured["curr_seg"] = curr_seg
+        captured["app_cfg"] = app_cfg
+        captured["direction"] = direction
+        captured["green_mask"] = g
+        captured["magenta_mask"] = m
+        return g, m
+
+    monkeypatch.setattr("app.ui.main_window._detect_green_magenta", capture_detect)
+
+    win._preview_gain_loss()
+
+    alpha = win.alpha_slider.value() / 100.0
+    expected_gm = np.zeros((3, 3, 3), dtype=np.uint8)
+    expected_gm[..., 1] = (win._reg_ref * (1 - alpha)).astype(np.uint8)
+    expected_gm[..., 0] = expected_gm[..., 2] = (win._reg_warp * alpha).astype(np.uint8)
+
+    expected_prev = real_segment(
+        win._reg_ref,
+        method="manual",
+        invert=False,
+        skip_outline=True,
+        manual_thresh=5,
+        adaptive_block=win.adaptive_blk.value(),
+        adaptive_C=win.adaptive_C.value(),
+        local_block=win.local_blk.value(),
+        morph_open_radius=win.open_r.value(),
+        morph_close_radius=win.close_r.value(),
+        remove_objects_smaller_px=win.rm_obj.value(),
+        remove_holes_smaller_px=win.rm_holes.value(),
+        use_clahe=win.use_clahe.isChecked(),
+    )
+
+    expected_curr = real_segment(
+        win._reg_warp,
+        method="manual",
+        invert=False,
+        skip_outline=True,
+        manual_thresh=5,
+        adaptive_block=win.adaptive_blk.value(),
+        adaptive_C=win.adaptive_C.value(),
+        local_block=win.local_blk.value(),
+        morph_open_radius=win.open_r.value(),
+        morph_close_radius=win.close_r.value(),
+        remove_objects_smaller_px=win.rm_obj.value(),
+        remove_holes_smaller_px=win.rm_holes.value(),
+        use_clahe=win.use_clahe.isChecked(),
+    )
+
+    app_cfg = {
+        "gm_thresh_method": win.gm_thresh_method.currentText(),
+        "gm_thresh_percentile": win.gm_thresh_percentile.value(),
+        "gm_close_kernel": win.gm_close_k.value(),
+        "gm_dilate_kernel": win.gm_dilate_k.value(),
+        "gm_saturation": win.gm_sat_slider.value() / 10.0,
+    }
+    expected_green, expected_magenta = real_detect(
+        expected_gm,
+        expected_prev,
+        expected_curr,
+        app_cfg,
+        direction=win.dir_combo.currentText(),
+    )
+
+    assert np.array_equal(captured["gm_composite"], expected_gm)
+    assert np.array_equal(captured["prev_seg"], expected_prev)
+    assert np.array_equal(captured["curr_seg"], expected_curr)
+    assert captured["app_cfg"] == app_cfg
+    assert captured["direction"] == win.dir_combo.currentText()
+    assert np.array_equal(captured["green_mask"], expected_green)
+    assert np.array_equal(captured["magenta_mask"], expected_magenta)
+
+    win.close()
+    app.quit()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,7 +6,7 @@ import pyqtgraph as pg
 pg.setConfigOptions(useOpenGL=False)
 
 from app.ui.main_window import MainWindow
-from app.models.config import save_preset, RegParams, SegParams, AppParams
+from app.models.config import save_preset, load_preset, RegParams, SegParams, AppParams
 
 
 def test_settings_persist(tmp_path):
@@ -50,6 +50,7 @@ def test_settings_persist(tmp_path):
     win.bg_sub_cb.setChecked(True)
     win.save_intermediates.setChecked(True)
     win.archive_intermediates.setChecked(True)
+    win.gm_sat_slider.setValue(15)
     win.close()
     app.processEvents()
 
@@ -84,6 +85,7 @@ def test_settings_persist(tmp_path):
     assert win2.bg_sub_cb.isChecked()
     assert win2.save_intermediates.isChecked()
     assert win2.archive_intermediates.isChecked()
+    assert win2.gm_sat_slider.value() == 15
     win2.close()
     app.quit()
 
@@ -136,3 +138,16 @@ def test_presets_path_persist(tmp_path, monkeypatch):
     assert win3.app.presets_path == str(preset_dir2)
     win3.close()
     app.quit()
+
+
+def test_preset_gm_params(tmp_path):
+    preset = tmp_path / "preset.json"
+    save_preset(
+        str(preset),
+        RegParams(),
+        SegParams(),
+        AppParams(gm_opacity=67, gm_saturation=1.5),
+    )
+    _, _, app = load_preset(str(preset))
+    assert app.gm_opacity == 67
+    assert app.gm_saturation == 1.5


### PR DESCRIPTION
## Summary
- document GM saturation control and persistence
- ensure GM parameters persist in settings and presets
- test gain/loss preview against detection logic

## Testing
- `pytest tests/test_gain_loss_preview.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c46dfc3c8324b49a786eb3acbaf1