### PR TITLE
Add gain/loss preview section gated by segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Usage notes: Yen excels on low-contrast backgrounds, while Multi-Otsu is suited for images with distinct histogram peaks.
 - Gain/loss preview adds `gm_saturation` control and persists `gm_opacity`/
   `gm_saturation` in saved presets and settings.
+- Collapsible **Gain/Loss Detection** section that becomes available only after a
+  successful segmentation preview.
 
 ### Changed
 - Green–magenta composite now blends frames using `gm_opacity` to weight the current frame.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ PNGs removed once processing finishes.
 - `diff/new/` — binary masks highlighting regions that newly appear, used for evaluation.
 - `diff/lost/` — binary masks highlighting regions that disappear, used for evaluation.
 
+### Gain/Loss Detection
+
+After a successful segmentation preview, a collapsible **Gain/Loss Detection**
+section becomes available below the segmentation controls. It exposes the
+thresholding, morphology and saturation settings for detecting newly appeared
+(magenta) or disappeared (green) regions and includes a preview button. The
+section and its preview button remain disabled until segmentation completes, and
+any new folder selection or parameter tweak collapses and disables it again.
+
 The separation between the magenta and green channels is determined in LAB
 color space using an adaptive threshold on the "a" channel. The composite
 itself blends the current frame with the previous according to

--- a/tests/test_gain_loss_preview.py
+++ b/tests/test_gain_loss_preview.py
@@ -63,6 +63,8 @@ def test_gain_loss_preview_matches_detection(tmp_path, monkeypatch):
 
     monkeypatch.setattr("app.ui.main_window._detect_green_magenta", capture_detect)
 
+    win._diff_gray = np.zeros((3, 3), dtype=np.uint8)
+    win._preview_segmentation()
     win._preview_gain_loss()
 
     alpha = win.alpha_slider.value() / 100.0


### PR DESCRIPTION
## Summary
- Move gain/loss controls into a new collapsible `Gain/Loss Detection` section
- Gate the section and preview button behind a successful segmentation preview
- Update gain/loss preview test to run segmentation first and document the new workflow

## Testing
- `pytest tests/test_gain_loss_preview.py::test_gain_loss_preview_matches_detection -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c91c0504832481599f8d8642a6da