### PR TITLE
Fix gain/loss preview orientation

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1583,7 +1583,9 @@ class MainWindow(QMainWindow):
                 if contours:
                     cv2.drawContours(overlay, contours, -1, color, 1)
             self._current_preview = "gain_loss"
-            self.view.setImage(cv2.cvtColor(overlay, cv2.COLOR_BGR2RGB))
+            self.view.setImage(
+                cv2.cvtColor(overlay, cv2.COLOR_BGR2RGB).transpose(1, 0, 2)
+            )
             self.status_label.setText("Gain/Loss preview successful.")
         except Exception as e:
             self.status_label.setText(f"Preview failed: {e}")


### PR DESCRIPTION
## Summary
- maintain landscape orientation when previewing gain/loss by transposing overlay before displaying

## Testing
- `pytest -q`
- `python - <<'PY'
import os, numpy as np
from PyQt6.QtWidgets import QApplication
from PyQt6.QtCore import QSettings
from app.ui.main_window import MainWindow

os.environ['QT_QPA_PLATFORM'] = 'offscreen'
QSettings.setDefaultFormat(QSettings.Format.IniFormat)
app = QApplication.instance() or QApplication([])
win = MainWindow()
win.seg_method.setCurrentText('manual')
win.invert.setChecked(False)
win.skip_outline.setChecked(True)
win.manual_t.setValue(5)
win.open_r.setValue(0)
win.close_r.setValue(0)
win.rm_obj.setValue(0)
win.rm_holes.setValue(0)
win.use_clahe.setChecked(False)
win.alpha_slider.setValue(60)
win.gm_sat_slider.setValue(10)
win._reg_ref = np.zeros((80,120), dtype=np.uint8)
win._reg_warp = np.zeros((80,120), dtype=np.uint8)
win._reg_ref[20:60,40:80] = 30
win._reg_warp[30:70,50:90] = 30
win._diff_gray = np.zeros((80,120), dtype=np.uint8)
win._preview_segmentation()
win._preview_gain_loss()
print('image shape:', win.view.imageItem.image.shape)
win.close()
app.quit()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c6cc46ebbc8324ac7a70879b44ee66