### PR TITLE
Avoid resetting gain/loss on its own controls

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1153,7 +1153,15 @@ class MainWindow(QMainWindow):
                 val = None
             name = sender.objectName() or sender.__class__.__name__
             logger.info("Parameter changed via %s: %s", name, val)
-        self._reset_gain_loss_preview()
+        gm_widgets = {
+            self.gm_thresh_method,
+            self.gm_thresh_percentile,
+            self.gm_close_k,
+            self.gm_dilate_k,
+            self.gm_sat_slider,
+        }
+        if sender not in gm_widgets:
+            self._reset_gain_loss_preview()
         if (
             sender is not None
             and hasattr(sender, "isEnabled")


### PR DESCRIPTION
## Summary
- Prevent gain/loss widgets from clearing their preview
- Keep other parameter changes resetting gain/loss as before

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6cde5196c8324a346537664f5249f