### PR TITLE
Handle sparse percentile thresholds

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -106,11 +106,19 @@ def _detect_green_magenta(
     thresh_method = str(app_cfg.get("gm_thresh_method", "otsu")).lower()
     if thresh_method == "percentile":
         perc = float(app_cfg.get("gm_thresh_percentile", 99.0))
-        gm_thresh = int(np.percentile(abs_a, perc))
+        abs_nonzero = abs_a[abs_a > 0]
+        if abs_nonzero.size > 0:
+            gm_thresh = int(np.percentile(abs_nonzero, perc))
+        else:
+            gm_thresh = int(
+                cv2.threshold(abs_a, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[0]
+            )
     else:
         gm_thresh = int(
             cv2.threshold(abs_a, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[0]
         )
+
+    gm_thresh = max(gm_thresh, 1)
 
     green_mask = (a_channel < -gm_thresh).astype(np.uint8)
     magenta_mask = (a_channel > gm_thresh).astype(np.uint8)

--- a/tests/test_gm_percentile_sparse.py
+++ b/tests/test_gm_percentile_sparse.py
@@ -1,0 +1,33 @@
+import numpy as np
+import cv2
+from pathlib import Path
+import sys
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.core.processing import _detect_green_magenta
+
+
+def test_percentile_sparse_threshold():
+    gm = np.zeros((8, 8, 3), dtype=np.uint8)
+    # High-intensity magenta and green differences
+    gm[1, 2] = (255, 0, 255)
+    gm[3, 4] = (0, 255, 0)
+    # Low-intensity noise that should be ignored
+    gm[0, 1] = (30, 0, 30)
+    gm[2, 0] = (0, 30, 0)
+
+    prev_seg = np.ones((8, 8), dtype=np.uint8)
+    curr_seg = np.ones((8, 8), dtype=np.uint8)
+    app_cfg = {"gm_thresh_method": "percentile", "gm_thresh_percentile": 50}
+
+    green, magenta = _detect_green_magenta(
+        gm, prev_seg, curr_seg, app_cfg, direction="first-to-last"
+    )
+
+    assert magenta.sum() == 1
+    assert green.sum() == 1
+    assert magenta[1, 2] == 1
+    assert green[3, 4] == 1
+    assert magenta[0, 1] == 0 and green[2, 0] == 0


### PR DESCRIPTION
## Summary
- Ignore zero values when computing green/magenta percentile thresholds and clamp to minimum of 1
- Add regression test for sparse percentile thresholds to ensure only high-intensity pixels are detected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6d7fa955c83248b132a8a14d145fb