### PR TITLE
Disable irrelevant GM controls

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -73,7 +73,6 @@ class MainWindow(QMainWindow):
         self._current_preview = None
         self._build_ui()
         self._update_seg_controls(self.seg_method.currentText())
-        self._update_gm_controls(self.gm_thresh_method.currentText())
         self._param_timer = QTimer(self)
         self._param_timer.setSingleShot(True)
         self._param_timer.setInterval(200)
@@ -151,8 +150,12 @@ class MainWindow(QMainWindow):
         self.local_blk.setEnabled(local)
 
     def _update_gm_controls(self, method: str) -> None:
-        """Enable percentile spin when using percentile threshold."""
-        self.gm_thresh_percentile.setEnabled(method == "percentile")
+        """Enable/disable gain/loss widgets based on threshold method."""
+        percentile = method == "percentile"
+        self.gm_thresh_percentile.setEnabled(percentile)
+        # Remaining controls are required for all methods
+        for w in (self.gm_close_k, self.gm_dilate_k, self.gm_sat_slider):
+            w.setEnabled(True)
 
     def _reset_gain_loss_preview(self, collapse: bool = True) -> None:
         """Disable gain/loss UI and reset segmentation flag."""
@@ -595,6 +598,7 @@ class MainWindow(QMainWindow):
         gm_layout.addWidget(self.gm_preview_btn)
         self.gm_section.setContentLayout(gm_layout)
         self.gm_section.setEnabled(False)
+        self._update_gm_controls(self.gm_thresh_method.currentText())
         controls.addWidget(self.gm_section)
         self._add_help(
             self.seg_method,

--- a/tests/test_gm_method_ui_controls.py
+++ b/tests/test_gm_method_ui_controls.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+import pyqtgraph as pg
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QSettings
+
+pg.setConfigOptions(useOpenGL=False)
+
+# Ensure application package importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.ui.main_window import MainWindow
+
+
+def test_gm_method_enables_expected_widgets(tmp_path):
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+
+    # Gain/loss section disabled by default; enable to test controls
+    win.gm_section.setEnabled(True)
+    win._update_gm_controls(win.gm_thresh_method.currentText())
+
+    # Otsu method disables percentile spin box
+    win.gm_thresh_method.setCurrentText("otsu")
+    assert not win.gm_thresh_percentile.isEnabled()
+    for w in (win.gm_close_k, win.gm_dilate_k, win.gm_sat_slider):
+        assert w.isEnabled()
+
+    # Percentile method enables percentile spin box
+    win.gm_thresh_method.setCurrentText("percentile")
+    assert win.gm_thresh_percentile.isEnabled()
+    for w in (win.gm_close_k, win.gm_dilate_k, win.gm_sat_slider):
+        assert w.isEnabled()
+
+    # Switch back to Otsu
+    win.gm_thresh_method.setCurrentText("otsu")
+    assert not win.gm_thresh_percentile.isEnabled()
+
+    win.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Disable percentile input when Otsu gain/loss thresholding is selected and ensure other GM controls stay enabled
- Initialize GM controls after building the method combo box
- Test that switching GM threshold methods updates enabled widgets

## Testing
- `pytest tests/test_gm_method_ui_controls.py -q`
- `pytest tests/test_gain_loss_preview.py -q`
- `pytest tests/test_segmentation_ui_controls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6db676480832492a65c65c18140bd