### PR TITLE
Organize registered intermediates by frame type

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -218,6 +218,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
     ensure_dir(out_dir)
     reg_dir = out_dir / "registered"; ensure_dir(reg_dir)
+    prev_dir = reg_dir / "prev"; ensure_dir(prev_dir)
+    mov_dir = reg_dir / "mov"; ensure_dir(mov_dir)
 
     diff_dir = out_dir / "diff"; ensure_dir(diff_dir)
     diff_raw_dir = diff_dir / "raw"; ensure_dir(diff_raw_dir)
@@ -645,10 +647,10 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
 
         if app_cfg.get("save_intermediates", False):
             cv2.imencode('.png', prev_crop)[1].tofile(
-                str(reg_dir / f"{prev_k:04d}_prev.png")
+                str(prev_dir / f"{prev_k:04d}_prev.png")
             )
             cv2.imencode('.png', mov_crop)[1].tofile(
-                str(reg_dir / f"{k:04d}_mov.png")
+                str(mov_dir / f"{k:04d}_mov.png")
             )
             overlay_color = tuple(app_cfg.get("overlay_mov_color", (255, 0, 255)))
             ov = overlay_outline(mov_crop, mask=seg_mask, color=overlay_color)

--- a/tests/test_synthetic_registration.py
+++ b/tests/test_synthetic_registration.py
@@ -65,10 +65,12 @@ def test_synthetic_registration_alignment(tmp_path):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     reg_dir = out_dir / "registered"
-    prev0 = cv2.imread(str(reg_dir / "0000_prev.png"), cv2.IMREAD_GRAYSCALE)
-    mov1 = cv2.imread(str(reg_dir / "0001_mov.png"), cv2.IMREAD_GRAYSCALE)
+    prev_dir = reg_dir / "prev"
+    mov_dir = reg_dir / "mov"
+    prev0 = cv2.imread(str(prev_dir / "0000_prev.png"), cv2.IMREAD_GRAYSCALE)
+    mov1 = cv2.imread(str(mov_dir / "0001_mov.png"), cv2.IMREAD_GRAYSCALE)
     assert np.array_equal(prev0, mov1)
 
-    prev1 = cv2.imread(str(reg_dir / "0001_prev.png"), cv2.IMREAD_GRAYSCALE)
-    mov2 = cv2.imread(str(reg_dir / "0002_mov.png"), cv2.IMREAD_GRAYSCALE)
+    prev1 = cv2.imread(str(prev_dir / "0001_prev.png"), cv2.IMREAD_GRAYSCALE)
+    mov2 = cv2.imread(str(mov_dir / "0002_mov.png"), cv2.IMREAD_GRAYSCALE)
     assert np.array_equal(prev1, mov2)


### PR DESCRIPTION
## Summary
- create `registered/prev` and `registered/mov` output directories
- save previous and moving frame crops to their respective directories
- adjust synthetic registration test for new paths

## Testing
- `pytest`
- `pytest tests/test_synthetic_registration.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6f675335c8324abcf27ccc89b056c