### PR TITLE
Persist green and magenta difference masks

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -227,6 +227,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     diff_gain_dir = diff_dir / "gain"; ensure_dir(diff_gain_dir)
     diff_loss_dir = diff_dir / "loss"; ensure_dir(diff_loss_dir)
     diff_gm_dir = diff_dir / "gm"; ensure_dir(diff_gm_dir)
+    diff_green_dir = diff_dir / "green"; ensure_dir(diff_green_dir)
+    diff_magenta_dir = diff_dir / "magenta"; ensure_dir(diff_magenta_dir)
 
     overlay_dir = out_dir / "overlay"; ensure_dir(overlay_dir)
 
@@ -557,6 +559,14 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             app_cfg,
             direction=direction,
         )
+
+        if idx > 0 and app_cfg.get("save_masks", False):
+            cv2.imencode('.png', (green_mask * 255).astype(np.uint8))[1].tofile(
+                str(diff_green_dir / f"{prev_k:04d}_bw_green.png")
+            )
+            cv2.imencode('.png', (magenta_mask * 255).astype(np.uint8))[1].tofile(
+                str(diff_magenta_dir / f"{prev_k:04d}_bw_magenta.png")
+            )
 
         if direction == "last-to-first":
             prev_bw_crop, seg_mask = seg_mask, prev_bw_crop

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -60,6 +60,8 @@ def test_difference_output(tmp_path, monkeypatch):
     assert (diff_dir / "lost" / "0000_bw_lost.png").exists()
     assert (diff_dir / "gain" / "0000_bw_gain.png").exists()
     assert (diff_dir / "loss" / "0000_bw_loss.png").exists()
+    assert (diff_dir / "green" / "0000_bw_green.png").exists()
+    assert (diff_dir / "magenta" / "0000_bw_magenta.png").exists()
 
 
 def test_difference_output_disabled(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Create `diff/green` and `diff/magenta` directories during processing setup
- Persist green and magenta masks returned by `_detect_green_magenta`
- Test ensures green and magenta mask files are generated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6fedaae988324a953b029a4a4927d