### PR TITLE
Save overlap and union diagnostic masks

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -229,6 +229,8 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     diff_gm_dir = diff_dir / "gm"; ensure_dir(diff_gm_dir)
     diff_green_dir = diff_dir / "green"; ensure_dir(diff_green_dir)
     diff_magenta_dir = diff_dir / "magenta"; ensure_dir(diff_magenta_dir)
+    diff_overlap_dir = diff_dir / "overlap"; ensure_dir(diff_overlap_dir)
+    diff_union_dir = diff_dir / "union"; ensure_dir(diff_union_dir)
 
     overlay_dir = out_dir / "overlay"; ensure_dir(overlay_dir)
 
@@ -566,6 +568,12 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
             )
             cv2.imencode('.png', (magenta_mask * 255).astype(np.uint8))[1].tofile(
                 str(diff_magenta_dir / f"{prev_k:04d}_bw_magenta.png")
+            )
+            cv2.imencode('.png', (bw_overlap * 255).astype(np.uint8))[1].tofile(
+                str(diff_overlap_dir / f"{prev_k:04d}_bw_overlap.png")
+            )
+            cv2.imencode('.png', (bw_union * 255).astype(np.uint8))[1].tofile(
+                str(diff_union_dir / f"{prev_k:04d}_bw_union.png")
             )
 
         if direction == "last-to-first":

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -93,9 +93,17 @@ def test_save_masks(tmp_path, monkeypatch):
 
     gain_path = out_dir / "diff" / "gain" / "0000_bw_gain.png"
     loss_path = out_dir / "diff" / "loss" / "0000_bw_loss.png"
+    overlap_path = out_dir / "diff" / "overlap" / "0000_bw_overlap.png"
+    union_path = out_dir / "diff" / "union" / "0000_bw_union.png"
     assert gain_path.exists()
     assert loss_path.exists()
+    assert overlap_path.exists()
+    assert union_path.exists()
     gain_mask = cv2.imread(str(gain_path), cv2.IMREAD_GRAYSCALE)
     loss_mask = cv2.imread(str(loss_path), cv2.IMREAD_GRAYSCALE)
+    overlap_mask = cv2.imread(str(overlap_path), cv2.IMREAD_GRAYSCALE)
+    union_mask = cv2.imread(str(union_path), cv2.IMREAD_GRAYSCALE)
     assert gain_mask.shape == img0.shape
     assert loss_mask.shape == img1.shape
+    assert overlap_mask.shape == img0.shape
+    assert union_mask.shape == img1.shape


### PR DESCRIPTION
## Summary
- create `diff/overlap` and `diff/union` output folders
- write overlap and union masks to their respective folders
- extend tests to cover new mask outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c705304640832497b05c2fa77f83d4