### PR TITLE
Add segmentation diagnostics output

### DIFF
--- a/app/core/processing.py
+++ b/app/core/processing.py
@@ -233,6 +233,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
     diff_union_dir = diff_dir / "union"; ensure_dir(diff_union_dir)
 
     overlay_dir = out_dir / "overlay"; ensure_dir(overlay_dir)
+    seg_dir = out_dir / "seg"; ensure_dir(seg_dir)
 
     gm_opacity = int(app_cfg.get("gm_opacity", 50))
 
@@ -528,6 +529,7 @@ def analyze_sequence(paths: List[Path], reg_cfg: dict, seg_cfg: dict, app_cfg: d
         # masks when regions vanished; the composite approach below resolves
         # this by comparing full-frame intensities.
         seg_mask = bw_reg
+        _save_mask(k, seg_mask, x_k, y_k, target_dir=seg_dir)
 
         if bw_diff is not None:
             _save_mask(

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -54,6 +54,7 @@ def test_difference_output(tmp_path, monkeypatch):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     diff_dir = out_dir / "diff"
+    seg_dir = out_dir / "seg"
     assert (diff_dir / "raw" / "0001_diff.png").exists()
     assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
     assert (diff_dir / "new" / "0000_bw_new.png").exists()
@@ -62,6 +63,8 @@ def test_difference_output(tmp_path, monkeypatch):
     assert (diff_dir / "loss" / "0000_bw_loss.png").exists()
     assert (diff_dir / "green" / "0000_bw_green.png").exists()
     assert (diff_dir / "magenta" / "0000_bw_magenta.png").exists()
+    assert (seg_dir / "mask_0000.png").exists()
+    assert (seg_dir / "mask_0000_overlay.png").exists()
 
 
 def test_difference_output_disabled(tmp_path, monkeypatch):
@@ -94,5 +97,7 @@ def test_difference_output_disabled(tmp_path, monkeypatch):
     analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
 
     diff_dir = out_dir / "diff"
+    seg_dir = out_dir / "seg"
     assert (diff_dir / "raw" / "0001_diff.png").exists()
     assert (diff_dir / "bw" / "0001_bw_diff.png").exists()
+    assert (seg_dir / "mask_0000.png").exists()

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -95,15 +95,21 @@ def test_save_masks(tmp_path, monkeypatch):
     loss_path = out_dir / "diff" / "loss" / "0000_bw_loss.png"
     overlap_path = out_dir / "diff" / "overlap" / "0000_bw_overlap.png"
     union_path = out_dir / "diff" / "union" / "0000_bw_union.png"
+    seg_mask_path = out_dir / "seg" / "mask_0000.png"
+    seg_overlay_path = out_dir / "seg" / "mask_0000_overlay.png"
     assert gain_path.exists()
     assert loss_path.exists()
     assert overlap_path.exists()
     assert union_path.exists()
+    assert seg_mask_path.exists()
+    assert seg_overlay_path.exists()
     gain_mask = cv2.imread(str(gain_path), cv2.IMREAD_GRAYSCALE)
     loss_mask = cv2.imread(str(loss_path), cv2.IMREAD_GRAYSCALE)
     overlap_mask = cv2.imread(str(overlap_path), cv2.IMREAD_GRAYSCALE)
     union_mask = cv2.imread(str(union_path), cv2.IMREAD_GRAYSCALE)
+    seg_mask = cv2.imread(str(seg_mask_path), cv2.IMREAD_GRAYSCALE)
     assert gain_mask.shape == img0.shape
     assert loss_mask.shape == img1.shape
     assert overlap_mask.shape == img0.shape
     assert union_mask.shape == img1.shape
+    assert seg_mask.shape == img0.shape


### PR DESCRIPTION
## Summary
- write segmentation masks and overlays to new `seg` diagnostics folder
- track segmentation outputs in pipeline tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c706827ad88324a8d755ba8f4a859a