### PR TITLE
Save a-channel diagnostics for GM detection

### DIFF
--- a/tests/test_gain_loss_preview.py
+++ b/tests/test_gain_loss_preview.py
@@ -54,8 +54,10 @@ def test_gain_loss_preview_matches_detection(tmp_path, monkeypatch):
 
     captured = {}
 
-    def capture_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction):
-        g, m = real_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction=direction)
+    def capture_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction, **kwargs):
+        g, m = real_detect(
+            gm_comp, prev_seg, curr_seg, app_cfg, direction=direction, **kwargs
+        )
         captured["gm_composite"] = gm_comp
         captured["prev_seg"] = prev_seg
         captured["curr_seg"] = curr_seg

--- a/tests/test_gm_composite_opacity.py
+++ b/tests/test_gm_composite_opacity.py
@@ -40,10 +40,17 @@ def test_gm_composite_opacity_and_saturation(tmp_path, monkeypatch):
 
     real_detect = processing._detect_green_magenta
 
-    def capture_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction):
+    def capture_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction, **kwargs):
         captured["gm_composite"] = gm_comp.copy()
         captured["app_cfg"] = dict(app_cfg)
-        return real_detect(gm_comp, prev_seg, curr_seg, app_cfg, direction=direction)
+        return real_detect(
+            gm_comp,
+            prev_seg,
+            curr_seg,
+            app_cfg,
+            direction=direction,
+            **kwargs,
+        )
 
     monkeypatch.setattr(processing, "_detect_green_magenta", capture_detect)
 


### PR DESCRIPTION
## Summary
- Write a-channel magnitude images before thresholding to `diff/a_channel`
- Log magenta histogram stats to show gm threshold vs amplitude
- Update overlay saving to segment the moving frame when saving previews

## Testing
- `pytest -q` *(fails: tests/test_empty_mask_warning.py::test_all_masks_empty_error, tests/test_growth_factor.py::test_final_mask_consistent_across_frames, tests/test_misregistration_tolerance.py::test_misregistration_tolerance[1-0-3], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[-1-0-3], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[0-1-3], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[0--1-3], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[2-0-5], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[-2-0-5], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[0-2-5], tests/test_misregistration_tolerance.py::test_misregistration_tolerance[0--2-5], tests/test_new_lost_direction.py::test_new_lost_direction, tests/test_new_lost_direction.py::test_intensity_gain_loss, tests/test_overlay_frame_alignment.py::test_overlay_frame_alignment, tests/test_overlay_new_lost_colors.py::test_overlay_contains_new_and_lost_colors, tests/test_per_frame_crop_rects.py::test_per_frame_crop_rectangles, tests/test_summary_metadata.py::test_summary_metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ec23c06c832481edbcbcc5a14839