### PR TITLE
feat: add asymmetric green-magenta thresholds

### DIFF
--- a/tests/test_gm_percentile_sparse.py
+++ b/tests/test_gm_percentile_sparse.py
@@ -10,17 +10,23 @@ from app.core.processing import _detect_green_magenta
 
 
 def test_percentile_sparse_threshold():
-    gm = np.zeros((8, 8, 3), dtype=np.uint8)
-    # High-intensity magenta and green differences
-    gm[1, 2] = (255, 0, 255)
-    gm[3, 4] = (0, 255, 0)
-    # Low-intensity noise that should be ignored
-    gm[0, 1] = (30, 0, 30)
-    gm[2, 0] = (0, 30, 0)
+    gm = np.zeros((5, 5, 3), dtype=np.uint8)
+    # Magenta differences with varying intensities
+    gm[1, 0] = (10, 0, 10)
+    gm[1, 1] = (20, 0, 20)
+    gm[1, 2] = (30, 0, 30)
+    # Green differences with higher intensities
+    gm[3, 2] = (0, 100, 0)
+    gm[3, 3] = (0, 200, 0)
+    gm[3, 4] = (0, 250, 0)
 
-    prev_seg = np.ones((8, 8), dtype=np.uint8)
-    curr_seg = np.ones((8, 8), dtype=np.uint8)
-    app_cfg = {"gm_thresh_method": "percentile", "gm_thresh_percentile": 50}
+    prev_seg = np.ones((5, 5), dtype=np.uint8)
+    curr_seg = np.ones((5, 5), dtype=np.uint8)
+    app_cfg = {
+        "gm_thresh_method": "percentile",
+        "gm_thresh_percentile_magenta": 50,
+        "gm_thresh_percentile_green": 50,
+    }
 
     green, magenta = _detect_green_magenta(
         gm, prev_seg, curr_seg, app_cfg, direction="first-to-last"
@@ -30,4 +36,6 @@ def test_percentile_sparse_threshold():
     assert green.sum() == 1
     assert magenta[1, 2] == 1
     assert green[3, 4] == 1
-    assert magenta[0, 1] == 0 and green[2, 0] == 0
+    assert magenta[1, 0] == 0 and magenta[1, 1] == 0
+    assert green[3, 2] == 0 and green[3, 3] == 0
+


### PR DESCRIPTION
## Summary
- allow independent green and magenta thresholds in `_detect_green_magenta`
- support `gm_thresh_percentile_magenta` and `gm_thresh_percentile_green`
- add test covering asymmetric percentile thresholds

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ValueError not raised; misregistration tolerance and other regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f189f8688324b73c563e4359ba60