### PR TITLE
Record diff mask shape properties and drop summary CSV

### DIFF
--- a/tests/test_diff_evaluation.py
+++ b/tests/test_diff_evaluation.py
@@ -61,7 +61,7 @@ def test_diff_evaluation(tmp_path, monkeypatch):
 
     monkeypatch.setattr(evaluation, "_read_mask", tracking_read)
 
-    df = evaluate_diff_masks(diff_dir, csv_path="summary.csv")
+    df = evaluate_diff_masks(diff_dir)
 
     assert df.shape[0] == 1
     row = df.iloc[0]
@@ -69,8 +69,6 @@ def test_diff_evaluation(tmp_path, monkeypatch):
     assert row["area_lost_px"] == 1
     assert row["net_new_px"] == 1
     assert row["area_diff_px"] == 3
-    assert (diff_dir / "summary.csv").exists()
-    assert not (tmp_path / "summary.csv").exists()
 
     diff_dir_res = diff_dir.resolve()
     all_paths = [p.resolve() for p in accessed_dirs + read_files]

--- a/tests/test_difference_output.py
+++ b/tests/test_difference_output.py
@@ -1,5 +1,6 @@
 import numpy as np
 import cv2
+import pandas as pd
 from pathlib import Path
 import sys
 
@@ -63,6 +64,11 @@ def test_difference_output(tmp_path, monkeypatch):
     assert (diff_dir / "loss" / "0000_bw_loss.png").exists()
     assert (diff_dir / "green" / "0000_bw_green.png").exists()
     assert (diff_dir / "magenta" / "0000_bw_magenta.png").exists()
+    bw_props = pd.read_csv(diff_dir / "bw" / "bw_props.csv")
+    assert bw_props.loc[0, "area_px"] == 32 * 32
+    assert bw_props.loc[0, "bbox_width"] == 32
+    assert bw_props.loc[0, "bbox_height"] == 32
+    assert (diff_dir / "gm" / "gm_props.csv").exists()
     assert (seg_dir / "mask_0000.png").exists()
     assert (seg_dir / "mask_0000_overlay.png").exists()
 

--- a/tests/test_empty_mask_warning.py
+++ b/tests/test_empty_mask_warning.py
@@ -114,4 +114,3 @@ def test_all_masks_empty_error(tmp_path):
     out_dir = tmp_path / "out"
     with pytest.raises(ValueError, match="All segmentation masks were empty"):
         analyze_sequence(paths, reg_cfg, seg_cfg, app_cfg, out_dir)
-    assert not (out_dir / "summary.csv").exists()

--- a/tests/test_evaluate_diff_masks.py
+++ b/tests/test_evaluate_diff_masks.py
@@ -39,11 +39,10 @@ def create_masks(tmp_path: Path) -> Path:
 
 def test_evaluate_diff_masks(tmp_path):
     diff_dir = create_masks(tmp_path)
-    df = evaluate_diff_masks(diff_dir, csv_path="summary.csv")
+    df = evaluate_diff_masks(diff_dir)
     assert df.shape[0] == 1
     row = df.iloc[0]
     assert row["area_new_px"] == 2
     assert row["area_lost_px"] == 1
     assert row["net_new_px"] == 1
     assert row["area_diff_px"] == 3
-    assert (diff_dir / "summary.csv").exists()


### PR DESCRIPTION
## Summary
- add `write_shape_properties` helper to log area, centroid, and bounding box data for mask components
- analyze_sequence writes component stats for bw, gm, green, and magenta masks and no longer creates `summary.csv`
- streamline `evaluate_diff_masks` and update tests for new CSV outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c829c4eaac8324badd770e7aaacef6