### PR TITLE
Add sequential subdirectory processing

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -81,6 +81,7 @@ class AppParams:
     scale_minmax: Optional[tuple[int, int]] = None
     presets_path: Optional[str] = None
     last_folder: str | None = None
+    process_subdirs: bool = False
 
 def save_preset(path: str, reg: RegParams, seg: SegParams, app: AppParams) -> None:
     data = {"reg": asdict(reg), "seg": asdict(seg), "app": asdict(app)}
@@ -96,6 +97,7 @@ def load_preset(path: str) -> tuple[RegParams, SegParams, AppParams]:
     app_data.setdefault("save_diagnostics", True)
     app_data.setdefault("show_diff_overlay", True)
     app_data.setdefault("archive_outputs", False)
+    app_data.setdefault("process_subdirs", False)
     for key in [
         "save_png",
         "save_intermediates",
@@ -127,6 +129,7 @@ def load_settings() -> tuple[RegParams, SegParams, AppParams]:
                 data.setdefault("save_diagnostics", True)
                 data.setdefault("show_diff_overlay", True)
                 data.setdefault("archive_outputs", False)
+                data.setdefault("process_subdirs", False)
                 for key in [
                     "save_png",
                     "save_intermediates",

--- a/tests/test_process_subdirs.py
+++ b/tests/test_process_subdirs.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import cv2
+import pytest
+
+pytest.importorskip("PyQt6.QtWidgets")
+from PyQt6.QtWidgets import QApplication
+
+
+def test_processes_subdirectories_sequentially(tmp_path, monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    app = QApplication.instance() or QApplication([])
+
+    from app.ui.main_window import MainWindow
+
+    win = MainWindow()
+    win.process_subdirs_cb.setChecked(True)
+
+    sub_a = tmp_path / "a"; sub_a.mkdir()
+    sub_b = tmp_path / "b"; sub_b.mkdir()
+    img = np.zeros((10, 10), dtype=np.uint8)
+    a_img = sub_a / "img.png"; cv2.imwrite(str(a_img), img)
+    b_img = sub_b / "img.png"; cv2.imwrite(str(b_img), img)
+
+    win.folder_edit.setText(str(tmp_path))
+    win.subdirs = sorted([sub_a, sub_b])
+    win.paths = [a_img]
+
+    calls = []
+
+    class DummySignal:
+        def __init__(self):
+            self._cb = None
+        def connect(self, cb):
+            self._cb = cb
+        def emit(self, *args, **kwargs):
+            if self._cb:
+                self._cb(*args, **kwargs)
+
+    class DummyThread:
+        def __init__(self):
+            self.started = DummySignal()
+        def start(self):
+            self.started.emit()
+        def quit(self):
+            pass
+        def wait(self):
+            pass
+
+    class DummyWorker:
+        finished = DummySignal()
+        failed = DummySignal()
+        def __init__(self, paths, reg_cfg, seg_cfg, app_cfg, out_dir):
+            calls.append((paths, out_dir, reg_cfg, seg_cfg, app_cfg))
+            self.out_dir = out_dir
+        def moveToThread(self, thread):
+            pass
+        def run(self):
+            self.finished.emit(str(self.out_dir))
+
+    monkeypatch.setattr("app.ui.main_window.QThread", DummyThread)
+    monkeypatch.setattr("app.ui.main_window.PipelineWorker", DummyWorker)
+
+    win._run_pipeline()
+
+    assert len(calls) == 2
+    assert Path(calls[0][1]) == sub_a / "_processed_pyqt"
+    assert Path(calls[1][1]) == sub_b / "_processed_pyqt"
+    assert calls[0][2] == calls[1][2]
+    assert calls[0][3] == calls[1][3]
+    assert calls[0][4] == calls[1][4]
+
+    win.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- allow configuring `process_subdirs` in settings
- expose "Process subdirectories" checkbox in main window and preview first subdirectory
- sequentially run pipeline over each immediate subdirectory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c83a7e55848324aa739bf1fd94c042